### PR TITLE
feat(ledge): polish setup, settings, and visitor UI

### DIFF
--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardPresenter.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardPresenter.cs
@@ -2,6 +2,8 @@ using UnityEngine;
 using System.Collections.Generic;
 using Magi.LedgeBoardGame.Models;
 using Magi.LedgeBoardGame.Config;
+using Magi.LedgeBoardGame.UI;
+using TMPro;
 using UnityEngine.UI;
 
 namespace Magi.LedgeBoardGame.Board
@@ -26,7 +28,24 @@ namespace Magi.LedgeBoardGame.Board
         private string _ownerName;
         private Image _backgroundImage;
         private Image _eliminatedOverlay;
-        private Text _titleLabel;
+        // Bottom-center kit "nameplate" — replaces the legacy top-of-board
+        // white title text. Glass pill with placeholder skin chip + owner
+        // name + optional ACTIVE caption when this is the current-turn
+        // board. Matches kit/ledge-board-game/project/ui/frame-hud-np.jsx
+        // → NamedBoard.
+        private GameObject _nameplate;
+        private TMP_Text _nameplateName;
+        private TMP_Text _nameplateActiveCaption;
+
+        // Control-handoff visitor chrome (CONTROL-HANDOFF-SPEC.md 2026-06-15):
+        // small pill above the board reading "<Name> is acting here" + a
+        // cool dot in the visitor's skin accent. Visible only while a
+        // visiting move is in flight on this board.
+        private GameObject _visitorPill;
+        private Image _visitorPillDot;
+        private TMP_Text _visitorPillName;
+        private int _activeVisitorEntryTileId = -1;
+
         private bool _isEliminated;
         private readonly Dictionary<int, SpaceView> _spaceViews = new Dictionary<int, SpaceView>();
 
@@ -42,8 +61,8 @@ namespace Magi.LedgeBoardGame.Board
             BuildSpaceViews();
             PositionSpaceViews();
             UpdateView();
-            EnsureTitleLabel();
-            RefreshTitleLabel();
+            EnsureNameplate();
+            RefreshNameplate();
         }
 
         /// Propagates a renamed player (see LedgeAction.SetDisplayName / U14)
@@ -54,43 +73,217 @@ namespace Magi.LedgeBoardGame.Board
         {
             if (string.Equals(_ownerName, ownerName, System.StringComparison.Ordinal)) return;
             _ownerName = ownerName;
-            RefreshTitleLabel();
+            RefreshNameplate();
             RefreshCenterSpaceLabel();
         }
 
-        /// U-126 birds-eye board title banner. Spawned above the board at a
-        /// distance proportional to the outer radius so it scales sensibly
-        /// with the presenter's configured size. Text is plain UnityEngine.UI.Text
-        /// to stay inside the existing Canvas without a TMP dependency on
-        /// this prefab. Null-safe — if no Canvas ancestor is found the label
-        /// quietly stays unspawned (board still renders fine).
-        private void EnsureTitleLabel()
+        /// Toggle the kit nameplate's ACTIVE caption + accent halo. Called
+        /// from GameController whenever the current-turn board changes (see
+        /// UpdateDreamCanvasActiveBoard). Idempotent — safe to call every
+        /// turn even when state hasn't changed.
+        public void SetActiveDisplay(bool active)
         {
-            if (_titleLabel != null) return;
-            var go = new GameObject("BoardTitleLabel");
+            if (_nameplateActiveCaption != null) _nameplateActiveCaption.gameObject.SetActive(active);
+            if (_nameplate == null) return;
+            var outline = _nameplate.GetComponent<Outline>();
+            if (outline == null) return;
+            outline.effectColor = active
+                ? new Color(LedgeUITokens.Accent.r, LedgeUITokens.Accent.g, LedgeUITokens.Accent.b, 0.55f)
+                : LedgeUITokens.PanelEdge2;
+        }
+
+        /// Apply the control-handoff visitor visualization (path glow on
+        /// the entry tile + pill tag near the board). Per
+        /// CONTROL-HANDOFF-SPEC.md the visitor's COOL skin accent is the
+        /// identity — never the warm turn accent. Pass entryTileId < 0 to
+        /// show the pill only (no tile glow).
+        public void SetVisitor(string visitorName, Color visitorAccent, int entryTileId)
+        {
+            ClearVisitorOverlayInternal();
+            EnsureVisitorPill();
+            if (_visitorPillName != null) _visitorPillName.text =
+                string.IsNullOrEmpty(visitorName) ? "Visitor is acting here" : $"{visitorName} is acting here";
+            if (_visitorPillDot != null) _visitorPillDot.color = visitorAccent;
+            if (_visitorPill != null) _visitorPill.SetActive(true);
+
+            if (entryTileId >= 0 && _spaceViews.TryGetValue(entryTileId, out var entryView) && entryView != null)
+            {
+                entryView.SetVisitorOverlay(visitorAccent);
+            }
+            _activeVisitorEntryTileId = entryTileId;
+        }
+
+        public void ClearVisitor()
+        {
+            ClearVisitorOverlayInternal();
+            if (_visitorPill != null) _visitorPill.SetActive(false);
+        }
+
+        private void ClearVisitorOverlayInternal()
+        {
+            if (_activeVisitorEntryTileId >= 0
+                && _spaceViews.TryGetValue(_activeVisitorEntryTileId, out var view)
+                && view != null)
+            {
+                view.ClearVisitorOverlay();
+            }
+            _activeVisitorEntryTileId = -1;
+        }
+
+        /// Glass pill anchored above the top of the board, sized to fit
+        /// "Name is acting here" at UI 12pt. Built once, reused by SetVisitor.
+        private void EnsureVisitorPill()
+        {
+            if (_visitorPill != null) return;
+
+            var go = new GameObject("VisitorPill", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Outline), typeof(HorizontalLayoutGroup), typeof(ContentSizeFitter));
             go.transform.SetParent(transform, false);
-            var rect = go.AddComponent<RectTransform>();
+            var rt = (RectTransform)go.transform;
+            rt.anchorMin = new Vector2(0.5f, 0.5f);
+            rt.anchorMax = new Vector2(0.5f, 0.5f);
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            // Above the board — clear of the outermost ledge tiles (which sit
+            // near ledgeRadius) so the pill never occludes the entry tile it
+            // annotates. Sits higher than the nameplate's mirror distance below.
+            rt.anchoredPosition = new Vector2(0f, ledgeRadius + 90f);
+
+            var bg = go.GetComponent<Image>();
+            bg.color = LedgeUITokens.Panel;
+            bg.raycastTarget = false;
+            var outline = go.GetComponent<Outline>();
+            outline.effectColor = LedgeUITokens.PanelEdge2;
+            outline.effectDistance = new Vector2(LedgeUITokens.HairlineWidth, -LedgeUITokens.HairlineWidth);
+
+            var hl = go.GetComponent<HorizontalLayoutGroup>();
+            hl.padding = new RectOffset(20, 24, 12, 12);
+            hl.spacing = 12f;
+            hl.childAlignment = TextAnchor.MiddleLeft;
+            hl.childControlWidth = false;
+            hl.childControlHeight = false;
+            hl.childForceExpandWidth = false;
+            hl.childForceExpandHeight = false;
+
+            var fitter = go.GetComponent<ContentSizeFitter>();
+            fitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            // Cool dot — visitor's skin accent.
+            var dotGo = new GameObject("Dot", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(LayoutElement));
+            dotGo.transform.SetParent(go.transform, false);
+            var dotRt = (RectTransform)dotGo.transform;
+            dotRt.sizeDelta = new Vector2(20f, 20f);
+            _visitorPillDot = dotGo.GetComponent<Image>();
+            _visitorPillDot.color = LedgeUITokens.AccentCool;
+            _visitorPillDot.raycastTarget = false;
+            var dotLe = dotGo.GetComponent<LayoutElement>();
+            dotLe.preferredWidth = 20f; dotLe.minWidth = 20f;
+            dotLe.preferredHeight = 20f; dotLe.minHeight = 20f;
+
+            // "<Name> is acting here" UI bold 18pt.
+            var nameGo = new GameObject("Label", typeof(RectTransform));
+            nameGo.transform.SetParent(go.transform, false);
+            _visitorPillName = nameGo.AddComponent<TextMeshProUGUI>();
+            _visitorPillName.font = LedgeUITokens.UIFont;
+            _visitorPillName.fontSize = 18f;
+            _visitorPillName.fontStyle = FontStyles.Bold;
+            _visitorPillName.color = LedgeUITokens.Ink;
+            _visitorPillName.alignment = TextAlignmentOptions.MidlineLeft;
+            _visitorPillName.text = "Visitor";
+            _visitorPillName.raycastTarget = false;
+
+            _visitorPill = go;
+            _visitorPill.SetActive(false);
+        }
+
+        /// Kit "nameplate" — glass pill at bottom-center of the board carrying
+        /// skin-chip + owner name. Replaces the legacy top-of-board white
+        /// Text banner. Mirrors frame-hud-np.jsx → NamedBoard. The skin chip
+        /// is a flat dark placeholder until the skin catalog lands. ACTIVE
+        /// caption (mono accent, hidden by default) toggles via
+        /// <see cref="SetActiveDisplay"/>.
+        private void EnsureNameplate()
+        {
+            if (_nameplate != null) return;
+
+            var go = new GameObject("BoardNameplate", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Outline));
+            go.transform.SetParent(transform, false);
+            var rect = (RectTransform)go.transform;
             rect.anchorMin = new Vector2(0.5f, 0.5f);
             rect.anchorMax = new Vector2(0.5f, 0.5f);
             rect.pivot = new Vector2(0.5f, 0.5f);
-            rect.anchoredPosition = new Vector2(0f, outerRadius + 60f);
-            rect.sizeDelta = new Vector2(outerRadius * 2.2f, 60f);
-            _titleLabel = go.AddComponent<Text>();
-            _titleLabel.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
-            _titleLabel.alignment = TextAnchor.MiddleCenter;
-            _titleLabel.fontSize = 28;
-            _titleLabel.color = Color.white;
-            _titleLabel.raycastTarget = false;
-            _titleLabel.horizontalOverflow = HorizontalWrapMode.Overflow;
-            _titleLabel.verticalOverflow = VerticalWrapMode.Overflow;
+            // Below the board, mirroring where the legacy title sat above it.
+            rect.anchoredPosition = new Vector2(0f, -(outerRadius + 60f));
+            rect.sizeDelta = new Vector2(outerRadius * 1.4f, 56f);
+
+            var bg = go.GetComponent<Image>();
+            bg.color = LedgeUITokens.Panel;
+            bg.raycastTarget = false;
+            var outline = go.GetComponent<Outline>();
+            outline.effectColor = LedgeUITokens.PanelEdge2;
+            outline.effectDistance = new Vector2(LedgeUITokens.HairlineWidth, -LedgeUITokens.HairlineWidth);
+
+            _nameplate = go;
+
+            // Skin chip — placeholder flat-dark square. Sized to read at
+            // multi-board distance (boards live at outerRadius ~400-500px).
+            var chipGo = new GameObject("SkinChip", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Outline));
+            chipGo.transform.SetParent(rect, false);
+            var chipRt = (RectTransform)chipGo.transform;
+            chipRt.anchorMin = new Vector2(0f, 0.5f);
+            chipRt.anchorMax = new Vector2(0f, 0.5f);
+            chipRt.pivot = new Vector2(0f, 0.5f);
+            chipRt.anchoredPosition = new Vector2(16f, 0f);
+            chipRt.sizeDelta = new Vector2(36f, 36f);
+            var chipImg = chipGo.GetComponent<Image>();
+            chipImg.color = new Color(0.10f, 0.12f, 0.22f, 1f); // ~#1A1F38 — kit fallback
+            chipImg.raycastTarget = false;
+            var chipOutline = chipGo.GetComponent<Outline>();
+            chipOutline.effectColor = LedgeUITokens.PanelEdge2;
+            chipOutline.effectDistance = new Vector2(LedgeUITokens.HairlineWidth, -LedgeUITokens.HairlineWidth);
+
+            // Name + ACTIVE caption stacked vertically to the right of chip.
+            _nameplateName = MakeNameplateText(rect, "Name", LedgeUITokens.UIFont, 24f, LedgeUITokens.Ink);
+            _nameplateName.fontStyle = FontStyles.Bold;
+            _nameplateName.alignment = TextAlignmentOptions.MidlineLeft;
+            var nameRt = _nameplateName.rectTransform;
+            nameRt.anchorMin = new Vector2(0f, 0f);
+            nameRt.anchorMax = new Vector2(1f, 1f);
+            nameRt.pivot = new Vector2(0f, 0.5f);
+            nameRt.offsetMin = new Vector2(60f, 0f);
+            nameRt.offsetMax = new Vector2(-16f, 0f);
+
+            _nameplateActiveCaption = MakeNameplateText(rect, "ActiveCaption", LedgeUITokens.MonoFont, 14f, LedgeUITokens.Accent);
+            _nameplateActiveCaption.text = "ACTIVE";
+            _nameplateActiveCaption.fontStyle = FontStyles.UpperCase;
+            _nameplateActiveCaption.characterSpacing = 18f;
+            _nameplateActiveCaption.alignment = TextAlignmentOptions.MidlineRight;
+            var activeRt = _nameplateActiveCaption.rectTransform;
+            activeRt.anchorMin = new Vector2(1f, 0.5f);
+            activeRt.anchorMax = new Vector2(1f, 0.5f);
+            activeRt.pivot = new Vector2(1f, 0.5f);
+            activeRt.anchoredPosition = new Vector2(-16f, 0f);
+            activeRt.sizeDelta = new Vector2(80f, 16f);
+            _nameplateActiveCaption.gameObject.SetActive(false);
         }
 
-        private void RefreshTitleLabel()
+        private void RefreshNameplate()
         {
-            if (_titleLabel == null) return;
-            _titleLabel.text = string.IsNullOrWhiteSpace(_ownerName)
+            if (_nameplateName == null) return;
+            _nameplateName.text = string.IsNullOrWhiteSpace(_ownerName)
                 ? (_boardState != null ? $"Board {_boardState.BoardId}" : "Board")
                 : _ownerName;
+        }
+
+        private static TMP_Text MakeNameplateText(Transform parent, string name, TMP_FontAsset font, float size, Color color)
+        {
+            var go = new GameObject(name, typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var t = go.AddComponent<TextMeshProUGUI>();
+            t.font = font;
+            t.fontSize = size;
+            t.color = color;
+            t.raycastTarget = false;
+            return t;
         }
 
         /// Only the Center space's label depends on ownerName

--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/SpaceView.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/SpaceView.cs
@@ -296,7 +296,7 @@ namespace Magi.LedgeBoardGame.Board
 
                 hoverLabelTMP = tmpGo.AddComponent<TextMeshProUGUI>();
                 hoverLabelTMP.alignment = TextAlignmentOptions.Center;
-                hoverLabelTMP.enableWordWrapping = true;
+                hoverLabelTMP.textWrappingMode = TextWrappingModes.Normal;
                 hoverLabelTMP.fontSize = hoverLabelFontSize;
                 hoverLabelTMP.color = hoverLabelColor;
                 hoverLabelTMP.raycastTarget = false;
@@ -411,6 +411,104 @@ namespace Magi.LedgeBoardGame.Board
         }
 
         public void SetHighlightColor(Color _) { }
+
+        // ── Visitor overlay (control-handoff spec, 2026-06-15) ─────────────
+        // A flat colored hex tint at the visitor's cool skin-accent at ~0.5
+        // alpha. Sits between fillImage and frameImage in the sibling order
+        // so it tints the wedge color without obscuring the frame or glow.
+        // Lazily built so untouched tiles stay zero-cost.
+        private Image _visitorOverlayImage;
+        private Image _visitorHaloImage;
+
+        // The flat tint alone can't be told apart from a tile whose fill is
+        // already near the visitor accent (many tiles are cyan/blue), so a
+        // brighter accent ring around the entry tile carries the recognition.
+        private const float VisitorHaloAlpha = 0.8f;
+
+        public void SetVisitorOverlay(Color accent, float alpha = 0.5f)
+        {
+            EnsureVisitorOverlayImage();
+            if (_visitorOverlayImage != null)
+            {
+                _visitorOverlayImage.color = new Color(accent.r, accent.g, accent.b, Mathf.Clamp01(alpha));
+                _visitorOverlayImage.gameObject.SetActive(true);
+            }
+
+            // Accent halo carries the "someone is acting here" recognition on
+            // top of the translucent fill tint.
+            EnsureVisitorHaloImage();
+            if (_visitorHaloImage != null)
+            {
+                _visitorHaloImage.color = new Color(accent.r, accent.g, accent.b, VisitorHaloAlpha);
+                _visitorHaloImage.gameObject.SetActive(true);
+            }
+        }
+
+        public void ClearVisitorOverlay()
+        {
+            if (_visitorOverlayImage != null) _visitorOverlayImage.gameObject.SetActive(false);
+            if (_visitorHaloImage != null) _visitorHaloImage.gameObject.SetActive(false);
+        }
+
+        private void EnsureVisitorOverlayImage()
+        {
+            if (_visitorOverlayImage != null) return;
+            // Mirror the fillImage hex sprite + rotation so the overlay
+            // shape matches the tile's actual outline. shapeRoot is the
+            // parent for the visual stack.
+            if (fillImage == null || shapeRoot == null) return;
+
+            var go = new GameObject("VisitorOverlay", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            var rt = (RectTransform)go.transform;
+            rt.SetParent(shapeRoot, false);
+            rt.anchorMin = Vector2.zero; rt.anchorMax = Vector2.one;
+            rt.offsetMin = Vector2.zero; rt.offsetMax = Vector2.zero;
+            rt.localRotation = fillImage.transform.localRotation;
+
+            _visitorOverlayImage = go.GetComponent<Image>();
+            _visitorOverlayImage.sprite = fillImage.sprite;
+            _visitorOverlayImage.raycastTarget = false;
+            _visitorOverlayImage.color = new Color(0f, 0f, 0f, 0f);
+
+            // Sit immediately above fillImage. Insert at fillImage's index+1
+            // so frameImage (drawn on top of fill) still sits above us.
+            int fillIdx = fillImage.transform.GetSiblingIndex();
+            go.transform.SetSiblingIndex(fillIdx + 1);
+            go.SetActive(false);
+        }
+
+        // Accent ring hugging the tile's outer edge. Reuses the shape-specific
+        // frame-glow sprite + rotation (already assigned by ApplyShapeAndFill)
+        // so the halo matches the hex / bridge / wall outline, and draws above
+        // the frame so the accent reads over the tile edge. Tokens still sit on
+        // top because countersRoot is a sibling of shapeRoot, not a child.
+        private void EnsureVisitorHaloImage()
+        {
+            if (_visitorHaloImage != null) return;
+            if (shapeRoot == null || frameGlowImage == null) return;
+
+            var selfRect = (RectTransform)transform;
+            var go = new GameObject("VisitorHalo", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            var rt = (RectTransform)go.transform;
+            rt.SetParent(shapeRoot, false);
+            rt.anchorMin = new Vector2(0.5f, 0.5f);
+            rt.anchorMax = new Vector2(0.5f, 0.5f);
+            rt.pivot = new Vector2(0.5f, 0.5f);
+            rt.anchoredPosition = Vector2.zero;
+            // Slightly larger than the frame glow (1.18f) so the accent reads as
+            // a ring around the tile rather than just a re-tint.
+            rt.sizeDelta = selfRect.sizeDelta * 1.22f;
+            rt.localRotation = frameGlowImage.transform.localRotation;
+
+            _visitorHaloImage = go.GetComponent<Image>();
+            _visitorHaloImage.sprite = frameGlowImage.sprite;
+            _visitorHaloImage.raycastTarget = false;
+            _visitorHaloImage.color = new Color(0f, 0f, 0f, 0f);
+
+            // Topmost shape element so the accent ring sits over the frame.
+            go.transform.SetAsLastSibling();
+            go.SetActive(false);
+        }
 
         public void OnPointerClick(PointerEventData eventData)
         {

--- a/LedgeBoardGame/Assets/_Project/Scripts/Net/LedgeLobbyBootstrap.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Net/LedgeLobbyBootstrap.cs
@@ -54,6 +54,9 @@ namespace Magi.LedgeBoardGame.Net
         [SerializeField] private string defaultSessionCode = "";
 
         private const string PlayerNamePrefKey = "ledge.playerName";
+        private const string SkinPrefKey = "ledge.boardSkin";
+        private const string TutorialNudgePrefKey = "ledge.tutorialNudgeShown";
+        private const string DefaultSkinId = "nightfall";
 
         private LobbyMode _mode = LobbyMode.Host;
         private int _seatCount;
@@ -81,6 +84,13 @@ namespace Magi.LedgeBoardGame.Net
 
         // ── Canvas widgets ──────────────────────────────────────────────────
         private Canvas _lobbyCanvas;
+        private GameObject _dreamBackdropGo;
+        private LedgeTitlePanel _titlePanel;
+        private LedgeTutorialPanel _tutorialPanel;
+        private LedgeSetupPanel _setupPanel;
+        private LedgeSettingsPanel _settingsPanel;
+        private bool _titleDismissed;
+        private string _selectedSkinId = DefaultSkinId;
         private GameObject _mainPanelGo;
         private GameObject _connectedBannerGo;
         private GameObject _quitOverlayGo;
@@ -120,9 +130,31 @@ namespace Magi.LedgeBoardGame.Net
             // non-empty, keeping the roster unchanged for anyone who leaves
             // the field blank.
             _playerName = PlayerPrefs.GetString(PlayerNamePrefKey, "") ?? "";
+            // F5: skin persists across sessions. Empty/missing falls back
+            // to the kit default ("nightfall"). The setup screen rehydrates
+            // from this value and writes the chosen one back on Ready.
+            _selectedSkinId = PlayerPrefs.GetString(SkinPrefKey, DefaultSkinId);
+            if (string.IsNullOrEmpty(_selectedSkinId)) _selectedSkinId = DefaultSkinId;
 
             BuildCanvas();
             RefreshUi();
+
+            // First-launch flow: no persisted name → start in setup so the
+            // player picks identity (name + skin) before seeing the title.
+            // Subsequent launches go straight to the title. F6 also tags
+            // the title's "How to play" button with a one-time pulse for
+            // first-launch sessions (gated on TutorialNudgePrefKey).
+            bool firstLaunch = string.IsNullOrEmpty(_playerName);
+            bool nudgeShown = PlayerPrefs.GetInt(TutorialNudgePrefKey, 0) != 0;
+            bool highlight = firstLaunch && !nudgeShown;
+            if (firstLaunch)
+            {
+                ShowSetup(onComplete: () => ShowTitle(highlightHowToPlay: highlight));
+            }
+            else
+            {
+                ShowTitle(highlightHowToPlay: false);
+            }
         }
 
         private void Update()
@@ -131,8 +163,32 @@ namespace Magi.LedgeBoardGame.Net
             var kb = Keyboard.current;
             if (kb != null && kb.escapeKey.wasPressedThisFrame)
             {
-                _showQuitConfirm = !_showQuitConfirm;
-                RefreshUi();
+                // Pop overlays in z-order: settings → setup → tutorial →
+                // title → quit confirm. (Each transient overlay can sit on
+                // top of any other; ESC backs out one layer at a time.)
+                if (_settingsPanel != null && _settingsPanel.IsShowing)
+                {
+                    _settingsPanel.Hide();
+                }
+                else if (_setupPanel != null && _setupPanel.IsShowing)
+                {
+                    _setupPanel.Hide();
+                }
+                else if (_tutorialPanel != null && _tutorialPanel.IsShowing)
+                {
+                    _tutorialPanel.Hide();
+                }
+                else if (!_titleDismissed && _titlePanel != null)
+                {
+                    _titleDismissed = true;
+                    _titlePanel.Hide();
+                    SelectMode(LobbyMode.Host);
+                }
+                else
+                {
+                    _showQuitConfirm = !_showQuitConfirm;
+                    RefreshUi();
+                }
             }
         }
 
@@ -439,10 +495,150 @@ namespace Magi.LedgeBoardGame.Net
             dreamGo.transform.SetParent(canvasGo.transform, false);
             dreamGo.transform.SetAsFirstSibling();
             dreamGo.AddComponent<LedgeDreamCanvas>();
+            _dreamBackdropGo = dreamGo;
 
             BuildMainPanel(canvasGo.transform);
             BuildConnectedBanner(canvasGo.transform);
             BuildQuitOverlay(canvasGo.transform);
+            BuildTutorialOverlay(canvasGo.transform);
+            BuildSetupOverlay(canvasGo.transform);
+            BuildSettingsOverlay(canvasGo.transform);
+            BuildTitleOverlay(canvasGo.transform);
+        }
+
+        /// Sibling Settings instance on the lobby canvas (the gameplay
+        /// canvas spawns its own). Title's "Settings" and the ESC menu's
+        /// Settings button both route here.
+        private void BuildSettingsOverlay(Transform canvasRoot)
+        {
+            var go = new GameObject("SettingsHost", typeof(RectTransform));
+            go.transform.SetParent(canvasRoot, false);
+            _settingsPanel = go.AddComponent<LedgeSettingsPanel>();
+        }
+
+        /// Open the full Settings panel (Audio / Motion / Accessibility /
+        /// Account). The Account section's "Edit display name" / "Change
+        /// skin" buttons route to Setup (F1 sub-route). onClose fires
+        /// when the user clicks Done.
+        public void ShowSettings(System.Action onClose = null)
+        {
+            if (_settingsPanel == null) return;
+            _settingsPanel.Show(
+                onClose: onClose,
+                // Account → Setup. After Setup commits/cancels, re-open
+                // Settings so the user can keep adjusting other tabs.
+                onEditProfile: () => ShowSetup(onComplete: () => ShowSettings(onClose)));
+        }
+
+        /// Setup (skin picker + name editor) starts hidden. Reachable via
+        /// the public ShowSetup() method — a future title/settings entry
+        /// point can call into it. Ready commits the chosen name + skin
+        /// and re-shows the lobby's main panel; Back just dismisses.
+        private void BuildSetupOverlay(Transform canvasRoot)
+        {
+            var go = new GameObject("SetupHost", typeof(RectTransform));
+            go.transform.SetParent(canvasRoot, false);
+            _setupPanel = go.AddComponent<LedgeSetupPanel>();
+        }
+
+        /// Trigger the setup screen with the currently-persisted name + skin.
+        /// Ready commits the chosen name to PlayerPrefs (same key the lobby
+        /// uses) and updates the in-memory skin selection. Both Ready and
+        /// Back fire <paramref name="onComplete"/> so the caller can route
+        /// what happens next (back to title, stay in lobby, etc.).
+        /// Skin doesn't persist yet — needs a separate PlayerPrefs key
+        /// once the skin catalog ships.
+        public void ShowSetup(System.Action onComplete = null)
+        {
+            if (_setupPanel == null) return;
+            _setupPanel.Show(
+                initialName: _playerName,
+                initialSkinId: _selectedSkinId,
+                onReady: (name, skinId) =>
+                {
+                    _playerName = (name ?? "").Trim();
+                    _selectedSkinId = string.IsNullOrEmpty(skinId) ? DefaultSkinId : skinId;
+                    if (_nameField != null) _nameField.SetTextWithoutNotify(_playerName);
+                    PlayerPrefs.SetString(PlayerNamePrefKey, _playerName);
+                    PlayerPrefs.SetString(SkinPrefKey, _selectedSkinId);
+                    PlayerPrefs.Save();
+                    try { onComplete?.Invoke(); }
+                    catch (System.Exception ex) { UnityEngine.Debug.LogError($"[lobby] setup-complete callback threw: {ex}"); }
+                },
+                onBack: onComplete);
+        }
+
+        /// Tutorial overlay starts hidden; the title's "How to play" handler
+        /// fires .Show(...). Spawned before the title so the title sits on
+        /// top until tutorial is invoked; Show() bumps it to the last sibling.
+        private void BuildTutorialOverlay(Transform canvasRoot)
+        {
+            var tutorialGo = new GameObject("TutorialHost", typeof(RectTransform));
+            tutorialGo.transform.SetParent(canvasRoot, false);
+            _tutorialPanel = tutorialGo.AddComponent<LedgeTutorialPanel>();
+        }
+
+        /// Kit title screen lives above the lobby chrome on the same canvas.
+        /// Spawned last so it sits on top of the main panel; the boot path
+        /// decides whether to Show() it immediately or run setup first
+        /// (see Awake's first-launch branch).
+        private void BuildTitleOverlay(Transform canvasRoot)
+        {
+            var titleGo = new GameObject("TitleHost", typeof(RectTransform));
+            titleGo.transform.SetParent(canvasRoot, false);
+            titleGo.transform.SetAsLastSibling();
+            _titlePanel = titleGo.AddComponent<LedgeTitlePanel>();
+        }
+
+        /// Show the title screen with the standard callback wiring. Called
+        /// from Awake (after the first-launch check) and after the user
+        /// closes setup/settings from the title.
+        private void ShowTitle(bool highlightHowToPlay = false)
+        {
+            if (_titlePanel == null) return;
+            // F6: mark the tutorial nudge as shown so subsequent launches
+            // don't re-pulse the How-to-play button.
+            if (highlightHowToPlay)
+            {
+                PlayerPrefs.SetInt(TutorialNudgePrefKey, 1);
+                PlayerPrefs.Save();
+            }
+            _titlePanel.Show(
+                onPlay: () =>
+                {
+                    _titleDismissed = true;
+                    SelectMode(LobbyMode.Host);
+                },
+                onPractice: () =>
+                {
+                    _titleDismissed = true;
+                    SelectMode(LobbyMode.Practice);
+                },
+                onHowToPlay: () =>
+                {
+                    // Tutorial sits over the title on the same canvas.
+                    // Start practice → dismiss title + tutorial, jump
+                    // straight to lobby's Practice tab. Skip → just hide
+                    // the tutorial; title remains visible underneath.
+                    if (_tutorialPanel == null) return;
+                    _tutorialPanel.Show(
+                        onStartPractice: () =>
+                        {
+                            _titleDismissed = true;
+                            _titlePanel?.Hide();
+                            SelectMode(LobbyMode.Practice);
+                        },
+                        onSkip: () => { /* tutorial hides itself; title still on screen */ });
+                },
+                onSettings: () =>
+                {
+                    // F1: Title's "Settings" opens the full Settings panel
+                    // (Audio / Motion / Accessibility / Account). Account's
+                    // Edit/Change buttons route into Setup as a sub-route.
+                    // Done returns to the title.
+                    ShowSettings(onClose: () => ShowTitle());
+                },
+                highlightHowToPlay: highlightHowToPlay);
         }
 
         private void BuildMainPanel(Transform canvasRoot)
@@ -456,7 +652,13 @@ namespace Magi.LedgeBoardGame.Net
             rt.sizeDelta = new Vector2(540f, 560f);
             rt.anchoredPosition = Vector2.zero;
 
-            var glass = LedgeGlassPanel.Build(_mainPanelGo.transform, "Glass", elevated: true);
+            // Panel chrome per kit/ledge-board-game/project/ui/frame-lobby.jsx
+            // → LobbyFrame: elevated (panel-2) + strongly-edged (panel-edge-2)
+            // + 44×40 padding. The wider horizontal padding lets fields breathe
+            // at the 540px panel width.
+            var glass = LedgeGlassPanel.Build(_mainPanelGo.transform, "Glass",
+                elevated: true, stronglyEdged: true,
+                padding: new Vector2(44f, 40f));
             var gRt = glass.GetComponent<RectTransform>();
             gRt.anchorMin = Vector2.zero; gRt.anchorMax = Vector2.one;
             gRt.offsetMin = Vector2.zero; gRt.offsetMax = Vector2.zero;
@@ -477,12 +679,22 @@ namespace Magi.LedgeBoardGame.Net
             vl.childForceExpandWidth = true;
             vl.childForceExpandHeight = false;
 
-            // Title
-            var title = BuildLabel(col, "Ledge — Lobby", LedgeUITokens.TurnBannerSize, LedgeUITokens.Ink);
+            // Title: "Ledge" Fraunces italic 40pt, then a separate centered
+            // "LOBBY" SectionLabel below. Mirrors the kit's two-piece title
+            // block (frame-lobby.jsx → LobbyFrame).
+            var title = BuildLabel(col, "Ledge", 40f, LedgeUITokens.Ink);
             title.font = LedgeUITokens.DisplayFont;
             title.fontStyle = FontStyles.Italic;
             title.alignment = TextAlignmentOptions.Center;
-            AddLayoutHeight(title.gameObject, 44f);
+            title.characterSpacing = -2f; // ~0.02em tighten per kit
+            AddLayoutHeight(title.gameObject, 48f);
+
+            var subtitle = BuildLabel(col, "LOBBY", LedgeUITokens.SectionLabelSize, LedgeUITokens.InkDim);
+            subtitle.font = LedgeUITokens.MonoFont;
+            subtitle.fontStyle = FontStyles.UpperCase;
+            subtitle.characterSpacing = 22f;
+            subtitle.alignment = TextAlignmentOptions.Center;
+            AddLayoutHeight(subtitle.gameObject, 14f);
 
             // Mode tab row
             var tabsRow = BuildHorizontalRow(col, "Tabs", 36f, 8f, TextAnchor.MiddleCenter, equalWidth: true);
@@ -503,6 +715,15 @@ namespace Magi.LedgeBoardGame.Net
             BuildSectionLabel(nameSection, "Your name (optional)");
             _nameField = BuildInputField(nameSection, "NameField", _playerName, "Anonymous");
             _nameField.onValueChanged.AddListener(v => _playerName = v ?? "");
+
+            // Edit-profile entry into the kit-faithful setup screen (skin
+            // picker + name editor with "how others see you" preview).
+            // Beneath the name section so it reads as the natural follow-on
+            // to "your name". Small Ghost Sm — explicitly de-emphasised vs
+            // the lobby's primary Go button.
+            var editBtn = LedgeButton.Build(nameSection, "Edit profile  →", LedgeButton.Variant.Ghost, LedgeButton.Size.Sm,
+                () => ShowSetup());
+            AddLayoutHeight(editBtn.gameObject, 26f);
 
             _hostUriRow = BuildSection(col, "HostUriSection").gameObject;
             BuildSectionLabel(_hostUriRow.transform, "Host base URI");
@@ -534,9 +755,9 @@ namespace Magi.LedgeBoardGame.Net
             _statusLabel.fontStyle = FontStyles.Italic;
             AddLayoutHeight(_statusLabel.gameObject, 22f);
 
-            // Go button
+            // Go button — full-width Ghost, 48px tall per the kit.
             _goButton = LedgeButton.Build(col, "Go", LedgeButton.Variant.Ghost, LedgeButton.Size.Lg, () => StartCoroutine(BeginFlow()));
-            AddLayoutHeight(_goButton.gameObject, 44f);
+            AddLayoutHeight(_goButton.gameObject, 48f);
 
             // Shared code row (post-host-connect)
             _sharedCodeRow = BuildSection(col, "SharedCodeSection").gameObject;
@@ -623,8 +844,14 @@ namespace Magi.LedgeBoardGame.Net
             prt.anchorMax = new Vector2(0.5f, 0.5f);
             prt.pivot = new Vector2(0.5f, 0.5f);
             prt.anchoredPosition = Vector2.zero;
-            prt.sizeDelta = new Vector2(380f, 200f);
-            var glass = LedgeGlassPanel.Build(panelGo.transform, "Glass", elevated: true, stronglyEdged: true);
+            // Panel sized to fit the kit's larger title (26pt) + 2-line body
+            // copy with extra padding (30 vertical / 32 horizontal per the
+            // kit). 380px wide; height grew from 260 to 380 once the F2
+            // Settings button joined the BackToLobby + Cancel/Quit stack.
+            prt.sizeDelta = new Vector2(380f, 380f);
+            var glass = LedgeGlassPanel.Build(panelGo.transform, "Glass",
+                elevated: true, stronglyEdged: true,
+                padding: new Vector2(32f, 30f));
             var gRt = glass.GetComponent<RectTransform>();
             gRt.anchorMin = Vector2.zero; gRt.anchorMax = Vector2.one;
             gRt.offsetMin = Vector2.zero; gRt.offsetMax = Vector2.zero;
@@ -639,20 +866,43 @@ namespace Magi.LedgeBoardGame.Net
             vl.childControlWidth = true; vl.childControlHeight = false;
             vl.childForceExpandWidth = true; vl.childForceExpandHeight = false;
 
-            _quitTitle = BuildLabel(col, "Quit Ledge?", LedgeUITokens.IdentNameSize, LedgeUITokens.Ink);
+            // Kit specifies the dialog title at 26pt Fraunces italic — a
+            // larger commitment than the lobby's compact section copy.
+            _quitTitle = BuildLabel(col, "Quit Ledge?", 26f, LedgeUITokens.Ink);
             _quitTitle.font = LedgeUITokens.DisplayFont;
             _quitTitle.fontStyle = FontStyles.Italic;
             _quitTitle.alignment = TextAlignmentOptions.Center;
-            AddLayoutHeight(_quitTitle.gameObject, 28f);
+            AddLayoutHeight(_quitTitle.gameObject, 36f);
 
-            _quitBody = BuildLabel(col, "Exit to desktop?", LedgeUITokens.BodySize, LedgeUITokens.InkFaint);
+            // Body wraps to two lines on a 380px panel at 13pt; enable word
+            // wrap explicitly so the kit copy doesn't run off the edge.
+            _quitBody = BuildLabel(col, "Exit to desktop?", 13f, LedgeUITokens.InkFaint);
             _quitBody.alignment = TextAlignmentOptions.Center;
-            AddLayoutHeight(_quitBody.gameObject, 20f);
+            _quitBody.textWrappingMode = TextWrappingModes.Normal;
+            AddLayoutHeight(_quitBody.gameObject, 60f);
 
             // Back-to-lobby (only visible when connected)
             _quitBackToLobbyGo = LedgeButton.Build(col, "Back to lobby", LedgeButton.Variant.Ghost, LedgeButton.Size.Md,
                 () => { _showQuitConfirm = false; ReloadScene(); }).gameObject;
             AddLayoutHeight(_quitBackToLobbyGo, 36f);
+
+            // F2: Settings button on the ESC menu. The kit's choice over a
+            // TR gear icon — settings live where the player already pauses.
+            // Hides the quit overlay and routes to the full Settings panel;
+            // closing Settings returns to the quit overlay rather than the
+            // game so the player can confirm or cancel from a single ESC.
+            var settingsBtn = LedgeButton.Build(col, "Settings", LedgeButton.Variant.Ghost, LedgeButton.Size.Md,
+                () =>
+                {
+                    _showQuitConfirm = false;
+                    RefreshUi();
+                    ShowSettings(onClose: () =>
+                    {
+                        _showQuitConfirm = true;
+                        RefreshUi();
+                    });
+                });
+            AddLayoutHeight(settingsBtn.gameObject, 36f);
 
             // Cancel | Quit row
             var btnRow = BuildHorizontalRow(col, "QuitButtons", 36f, 8f, TextAnchor.MiddleCenter, equalWidth: true);
@@ -704,8 +954,26 @@ namespace Magi.LedgeBoardGame.Net
                 _goButton.UnityButton.interactable = canGo;
             }
 
-            // Status
-            if (_statusLabel != null) _statusLabel.text = _status ?? "";
+            // Status: dynamic message (connecting, failed, …) takes precedence;
+            // otherwise show the kit's mode-contextual tagline so the slot
+            // always reads intentional rather than empty.
+            if (_statusLabel != null)
+            {
+                if (!string.IsNullOrEmpty(_status))
+                {
+                    _statusLabel.text = _status;
+                }
+                else
+                {
+                    _statusLabel.text = _mode switch
+                    {
+                        LobbyMode.Practice => "Pass-and-play on one device.",
+                        LobbyMode.Host => "Ready when you are.",
+                        LobbyMode.Join => "Ready when you are.",
+                        _ => "",
+                    };
+                }
+            }
 
             // Shared code row visibility + content
             bool showShared = !string.IsNullOrEmpty(_sharedCode) && _uiState != UiState.Connected;
@@ -714,8 +982,19 @@ namespace Magi.LedgeBoardGame.Net
 
             // Main panel visibility: hidden once connected so the in-game
             // chrome can take the screen. Still hidden behind the quit
-            // overlay during pre-connect Escape presses (the scrim covers it).
-            if (_mainPanelGo != null) _mainPanelGo.SetActive(_uiState != UiState.Connected);
+            // overlay during pre-connect Escape presses (the scrim covers
+            // it). Also hidden while the title is still up — the title's
+            // Play/Practice buttons set _titleDismissed so the lobby
+            // appears underneath when those handlers fire.
+            if (_mainPanelGo != null)
+                _mainPanelGo.SetActive(_uiState != UiState.Connected && _titleDismissed);
+
+            // The dream backdrop is opaque fullscreen at lobby sortingOrder
+            // 100, so leaving it active once Connected would paint over the
+            // main Canvas (boards live there at sortingOrder 0). The in-game
+            // EnsureDreamCanvas spawns its own backdrop on the main Canvas,
+            // so dropping the lobby's here is the right hand-off.
+            if (_dreamBackdropGo != null) _dreamBackdropGo.SetActive(_uiState != UiState.Connected);
 
             // Connected banner (TL): host-only, only when we have a code.
             bool showBanner = _uiState == UiState.Connected
@@ -728,7 +1007,9 @@ namespace Magi.LedgeBoardGame.Net
             bool connected = _uiState == UiState.Connected;
             if (_quitOverlayGo != null) _quitOverlayGo.SetActive(_showQuitConfirm);
             if (_quitTitle != null) _quitTitle.text = connected ? "Leave session?" : "Quit Ledge?";
-            if (_quitBody != null) _quitBody.text = connected ? "Return to the lobby or quit to desktop?" : "Exit to desktop?";
+            if (_quitBody != null) _quitBody.text = connected
+                ? "Your seat stays open — you can rejoin with the session code while the game lasts."
+                : "You can pick up a practice game any time.";
             if (_quitBackToLobbyGo != null) _quitBackToLobbyGo.SetActive(connected);
         }
 

--- a/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeSettingsPanel.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeSettingsPanel.cs
@@ -1,0 +1,756 @@
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Magi.LedgeBoardGame.UI
+{
+    /// Settings screen. Built from
+    /// `kit/ledge-board-game/project/ui/frame-settings.jsx` → SettingsFrame:
+    /// Fraunces italic title + mono section label + 2×2 grid of glass panels
+    /// (Audio · Motion · Accessibility · Account). Each row is label/hint +
+    /// a control (Toggle / Slider / Segmented / Button).
+    ///
+    /// Kit-faithful chrome only: clicking a Toggle / dragging a Slider /
+    /// picking a Segmented option updates the visual state but does NOT
+    /// persist or feed any system. The persistence layer (PlayerPrefs or a
+    /// settings ScriptableObject) and the actually-wired toggles (reduced-
+    /// motion → LedgeDreamCanvas, audio mute, colorblind aid, etc.) land
+    /// in a follow-up pass — at that point each control's onChange callback
+    /// becomes the integration point.
+    ///
+    /// Controls (Toggle, Slider, Segmented) are defined inline rather than
+    /// promoted to shared components yet — they have a single consumer here.
+    /// Promote when Player Setup or another surface needs them too (v4
+    /// handoff §4 lists this as a deferred promotion).
+    public class LedgeSettingsPanel : MonoBehaviour
+    {
+        private GameObject _overlayGo;
+
+        // Responsive refs (see ApplyResponsiveLayout). Cached from BuildUi so we
+        // can switch the 2×2 landscape grid to a single-column portrait layout
+        // when the canvas is too narrow to fit the 1000-wide frame.
+        private RectTransform _canvasRt;
+        private RectTransform _contentRt;
+        private RectTransform _gridRt;
+        private GridLayoutGroup _gridLayout;
+        private float _lastCanvasWidth = -1f;
+
+        // Landscape frame constants (the accepted cp017 layout).
+        private const float FrameW = 1000f;
+        private const float FrameH = 700f;
+        private const float GridPadTop = 140f; // header (title + sublabel) reserve
+        private const float GridPadSide = 40f;
+        private const float GridPadBottom = 40f;
+
+        private Action _onClose;
+        // Account sub-routes — fired by the Account panel's Edit/Change
+        // buttons. Setting either lets a caller plug Settings → Setup as
+        // the kit's F1 decision specifies. Null = button stays a stub log.
+        private Action _onEditProfile;
+
+        // ── Stub state (kit-faithful, not persisted) ───────────────────────
+        private float _audioMaster = 0.72f;
+        private float _audioMusic = 0.40f;
+        private float _audioSfx = 0.85f;
+        private bool _motionRipple = true;
+        private bool _motionReduced = false;
+        private bool _motionStarfield = true;
+        private string _a11yContrast = "Standard";
+        private bool _a11yColorblind = false;
+        private string _a11yTextSize = "M";
+
+        private void Awake() => EnsureBuilt();
+
+        public void EnsureBuilt()
+        {
+            if (_overlayGo != null) return;
+            BuildUi();
+            HideInternal();
+        }
+
+        // ── Public API ─────────────────────────────────────────────────────
+
+        public void Show(Action onClose = null, Action onEditProfile = null)
+        {
+            EnsureBuilt();
+            _onClose = onClose;
+            _onEditProfile = onEditProfile;
+            _overlayGo.SetActive(true);
+            _overlayGo.transform.SetAsLastSibling();
+            ApplyResponsiveLayout();
+        }
+
+        // Re-fit if the canvas width changes while Settings is open (e.g. a
+        // device rotation / window resize). Cheap early-out on unchanged width.
+        private void Update()
+        {
+            if (!IsShowing || _canvasRt == null) return;
+            if (!Mathf.Approximately(_canvasRt.rect.width, _lastCanvasWidth))
+                ApplyResponsiveLayout();
+        }
+
+        public void Hide() => HideInternal();
+
+        public bool IsShowing => _overlayGo != null && _overlayGo.activeSelf;
+
+        [ContextMenu("Show Settings (Test)")]
+        private void ShowTestPreview()
+        {
+            Show(() => UnityEngine.Debug.Log("[settings] Closed (test)"));
+        }
+
+        // ── Internals ─────────────────────────────────────────────────────
+
+        private void HideInternal()
+        {
+            if (_overlayGo != null) _overlayGo.SetActive(false);
+        }
+
+        private void FireAndClose()
+        {
+            HideInternal();
+            try { _onClose?.Invoke(); }
+            catch (Exception ex) { UnityEngine.Debug.LogError($"[settings] close callback threw: {ex}"); }
+        }
+
+        // ── UI construction ───────────────────────────────────────────────
+
+        private void BuildUi()
+        {
+            var canvas = GetComponentInParent<Canvas>();
+            if (canvas == null) return;
+
+            _overlayGo = new GameObject("SettingsOverlay", typeof(RectTransform));
+            var overlayRt = (RectTransform)_overlayGo.transform;
+            overlayRt.SetParent(canvas.transform, false);
+            overlayRt.anchorMin = Vector2.zero; overlayRt.anchorMax = Vector2.one;
+            overlayRt.offsetMin = Vector2.zero; overlayRt.offsetMax = Vector2.zero;
+            overlayRt.SetAsLastSibling();
+
+            // Solid backdrop — settings is a full takeover, not a floating modal.
+            var bgGo = new GameObject("Backdrop", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            var bgRt = (RectTransform)bgGo.transform;
+            bgRt.SetParent(overlayRt, false);
+            bgRt.anchorMin = Vector2.zero; bgRt.anchorMax = Vector2.one;
+            bgRt.offsetMin = Vector2.zero; bgRt.offsetMax = Vector2.zero;
+            var bgImg = bgGo.GetComponent<Image>();
+            bgImg.color = LedgeUITokens.Canvas;
+            bgImg.raycastTarget = true;
+
+            // Content frame — 1000×700 inset on the 1600×900 canvas (kit's
+            // native size for this surface). Centered.
+            var contentGo = new GameObject("Content", typeof(RectTransform));
+            var contentRt = (RectTransform)contentGo.transform;
+            contentRt.SetParent(overlayRt, false);
+            contentRt.anchorMin = new Vector2(0.5f, 0.5f);
+            contentRt.anchorMax = new Vector2(0.5f, 0.5f);
+            contentRt.pivot = new Vector2(0.5f, 0.5f);
+            contentRt.anchoredPosition = Vector2.zero;
+            contentRt.sizeDelta = new Vector2(FrameW, FrameH);
+            _contentRt = contentRt;
+            _canvasRt = canvas.transform as RectTransform;
+
+            // Header: Fraunces italic "Settings" + SectionLabel breadcrumb.
+            var titleGo = MakeText(contentRt, "Title", LedgeUITokens.DisplayFont, 40f, LedgeUITokens.Ink, "Settings").rectTransform;
+            var titleTmp = titleGo.GetComponent<TMP_Text>();
+            titleTmp.fontStyle = FontStyles.Italic;
+            titleTmp.alignment = TextAlignmentOptions.TopLeft;
+            titleGo.anchorMin = new Vector2(0f, 1f);
+            titleGo.anchorMax = new Vector2(1f, 1f);
+            titleGo.pivot = new Vector2(0f, 1f);
+            titleGo.anchoredPosition = new Vector2(40f, -40f);
+            titleGo.sizeDelta = new Vector2(-80f, 48f);
+
+            var sublabel = MakeText(contentRt, "Sublabel", LedgeUITokens.MonoFont,
+                LedgeUITokens.SectionLabelSize, LedgeUITokens.InkDim,
+                "AUDIO · MOTION · ACCESSIBILITY · ACCOUNT");
+            sublabel.fontStyle = FontStyles.UpperCase;
+            sublabel.characterSpacing = 22f;
+            sublabel.alignment = TextAlignmentOptions.TopLeft;
+            var subRt = sublabel.rectTransform;
+            subRt.anchorMin = new Vector2(0f, 1f);
+            subRt.anchorMax = new Vector2(1f, 1f);
+            subRt.pivot = new Vector2(0f, 1f);
+            subRt.anchoredPosition = new Vector2(40f, -94f);
+            subRt.sizeDelta = new Vector2(-80f, 14f);
+
+            // Done button — top-right. The kit doesn't show one (the screen
+            // is meant to compose into a larger nav flow), but as a free-
+            // standing overlay we need an explicit exit.
+            var doneBtn = LedgeButton.Build(contentRt, "Done", LedgeButton.Variant.Ghost, LedgeButton.Size.Md, FireAndClose);
+            var doneRt = doneBtn.GetComponent<RectTransform>();
+            doneRt.anchorMin = new Vector2(1f, 1f);
+            doneRt.anchorMax = new Vector2(1f, 1f);
+            doneRt.pivot = new Vector2(1f, 1f);
+            doneRt.anchoredPosition = new Vector2(-40f, -42f);
+            doneRt.sizeDelta = new Vector2(100f, 36f);
+
+            // 2×2 grid of glass panels.
+            var gridGo = new GameObject("Grid", typeof(RectTransform));
+            var gridRt = (RectTransform)gridGo.transform;
+            gridRt.SetParent(contentRt, false);
+            gridRt.anchorMin = new Vector2(0f, 0f);
+            gridRt.anchorMax = new Vector2(1f, 1f);
+            gridRt.pivot = new Vector2(0.5f, 0.5f);
+            gridRt.offsetMin = new Vector2(GridPadSide, GridPadBottom);
+            gridRt.offsetMax = new Vector2(-GridPadSide, -GridPadTop);
+
+            var gl = gridGo.AddComponent<GridLayoutGroup>();
+            gl.cellSize = new Vector2(450f, 240f);
+            gl.spacing = new Vector2(20f, 20f);
+            gl.childAlignment = TextAnchor.UpperLeft;
+            gl.startCorner = GridLayoutGroup.Corner.UpperLeft;
+            gl.startAxis = GridLayoutGroup.Axis.Horizontal;
+            gl.constraint = GridLayoutGroup.Constraint.FixedColumnCount;
+            gl.constraintCount = 2;
+            _gridRt = gridRt;
+            _gridLayout = gl;
+
+            BuildAudioPanel(gridRt);
+            BuildMotionPanel(gridRt);
+            BuildAccessibilityPanel(gridRt);
+            BuildAccountPanel(gridRt);
+
+            // Pick landscape vs. narrow-portrait layout based on canvas width.
+            ApplyResponsiveLayout();
+        }
+
+        // ── Responsive layout ─────────────────────────────────────────────
+        // Landscape/16:9 keeps the accepted cp017 2×2 grid (1000×700 frame,
+        // 450×240 cells). When the canvas is too narrow to fit the 1000-wide
+        // frame with margins (e.g. 720×1280 portrait → ~900 ref-units wide), we
+        // switch to a single-column layout: the frame is clamped to the canvas
+        // width with side margins, the grid becomes 1 column, and each card
+        // spans the full grid width. The frame grows taller (4 stacked cards)
+        // but stays within portrait height. Called after build, on Show(), and
+        // on canvas-width change while visible.
+        private void ApplyResponsiveLayout()
+        {
+            if (_contentRt == null || _gridRt == null || _gridLayout == null) return;
+            if (_canvasRt == null) _canvasRt = _overlayGo != null ? _overlayGo.transform.parent as RectTransform : null;
+            if (_canvasRt == null) return;
+
+            float canvasW = _canvasRt.rect.width;
+            float canvasH = _canvasRt.rect.height;
+            _lastCanvasWidth = canvasW;
+
+            const float SideMargin = 32f;
+            // Narrow when the landscape frame + a small margin can't fit.
+            bool narrow = canvasW < FrameW + 2f * SideMargin;
+
+            if (!narrow)
+            {
+                // Landscape / accepted layout.
+                _contentRt.sizeDelta = new Vector2(FrameW, FrameH);
+                _gridRt.offsetMin = new Vector2(GridPadSide, GridPadBottom);
+                _gridRt.offsetMax = new Vector2(-GridPadSide, -GridPadTop);
+                _gridLayout.constraintCount = 2;
+                _gridLayout.cellSize = new Vector2(450f, 240f);
+                return;
+            }
+
+            // Narrow / portrait: single column, frame clamped to canvas width.
+            float contentW = Mathf.Min(FrameW, canvasW - 2f * SideMargin);
+            float gridW = contentW - 2f * GridPadSide;
+            const float cellH = 240f;
+            float spacing = _gridLayout.spacing.y;
+            // Four stacked cards + inter-card spacing + header/bottom reserves.
+            float contentH = GridPadTop + (4f * cellH + 3f * spacing) + GridPadBottom;
+            // Never exceed the canvas height (leave a small top/bottom margin).
+            contentH = Mathf.Min(contentH, canvasH - 2f * SideMargin);
+
+            _contentRt.sizeDelta = new Vector2(contentW, contentH);
+            _gridRt.offsetMin = new Vector2(GridPadSide, GridPadBottom);
+            _gridRt.offsetMax = new Vector2(-GridPadSide, -GridPadTop);
+            _gridLayout.constraintCount = 1;
+            _gridLayout.cellSize = new Vector2(gridW, cellH);
+        }
+
+        private void BuildAudioPanel(Transform parent)
+        {
+            var col = BuildPanel(parent, "Audio");
+            BuildSliderRow(col, "Master volume", null, _audioMaster, v => _audioMaster = v);
+            BuildSliderRow(col, "Music", null, _audioMusic, v => _audioMusic = v);
+            BuildSliderRow(col, "Sound effects", null, _audioSfx, v => _audioSfx = v);
+        }
+
+        private void BuildMotionPanel(Transform parent)
+        {
+            var col = BuildPanel(parent, "Motion");
+            BuildToggleRow(col, "Board ripple & breathe", "Valid-target and source pulses", _motionRipple, v => _motionRipple = v);
+            BuildToggleRow(col, "Reduced motion", "Calmer transitions", _motionReduced, v => _motionReduced = v);
+            BuildToggleRow(col, "Backdrop starfield", null, _motionStarfield, v => _motionStarfield = v);
+        }
+
+        private void BuildAccessibilityPanel(Transform parent)
+        {
+            var col = BuildPanel(parent, "Accessibility");
+            BuildSegmentedRow(col, "Counter contrast", null, new[] { "Standard", "High" }, _a11yContrast, v => _a11yContrast = v);
+            BuildToggleRow(col, "Colorblind aid", "Tone glyphs on counters", _a11yColorblind, v => _a11yColorblind = v);
+            BuildSegmentedRow(col, "UI text size", null, new[] { "S", "M", "L" }, _a11yTextSize, v => _a11yTextSize = v);
+        }
+
+        private void BuildAccountPanel(Transform parent)
+        {
+            var col = BuildPanel(parent, "Account");
+            // F1: Display-name and Board-skin both route into the Setup
+            // screen (the kit's "Settings → Account → Setup" sub-route).
+            // If no onEditProfile is wired by the caller, both fall back
+            // to a stub log so the buttons stay clickable.
+            BuildButtonRow(col, "Display name", "Aurelia", "Edit",
+                () => FireEditProfileOrStub("Edit display name"));
+            BuildButtonRow(col, "Board skin", "Nightfall", "Change",
+                () => FireEditProfileOrStub("Change skin"));
+            BuildButtonRow(col, "Sign out", null, "Sign out",
+                () => UnityEngine.Debug.Log("[settings] Sign out (stub)"));
+        }
+
+        private void FireEditProfileOrStub(string action)
+        {
+            if (_onEditProfile != null)
+            {
+                HideInternal();
+                try { _onEditProfile.Invoke(); }
+                catch (Exception ex) { UnityEngine.Debug.LogError($"[settings] onEditProfile threw: {ex}"); }
+            }
+            else
+            {
+                UnityEngine.Debug.Log($"[settings] {action} (stub — no editor wired)");
+            }
+        }
+
+        // ── Panel + Row primitives ────────────────────────────────────────
+
+        private static RectTransform BuildPanel(Transform parent, string title)
+        {
+            var hostGo = new GameObject($"Panel_{title}", typeof(RectTransform));
+            var hostRt = (RectTransform)hostGo.transform;
+            hostRt.SetParent(parent, false);
+
+            var glass = LedgeGlassPanel.Build(hostRt, "Glass",
+                padding: new Vector2(22f, 8f));
+            var gRt = glass.GetComponent<RectTransform>();
+            gRt.anchorMin = Vector2.zero; gRt.anchorMax = Vector2.one;
+            gRt.offsetMin = Vector2.zero; gRt.offsetMax = Vector2.zero;
+
+            var content = new GameObject("Col", typeof(RectTransform));
+            var contentRt = (RectTransform)content.transform;
+            contentRt.SetParent(glass.Content, false);
+            contentRt.anchorMin = Vector2.zero; contentRt.anchorMax = Vector2.one;
+            contentRt.offsetMin = Vector2.zero; contentRt.offsetMax = Vector2.zero;
+            var vl = content.AddComponent<VerticalLayoutGroup>();
+            vl.spacing = 0f;
+            vl.childAlignment = TextAnchor.UpperLeft;
+            vl.childControlWidth = true;
+            // Control height so each row's declared LayoutElement height (50px)
+            // sizes it. With it false the rows kept their default rect height
+            // and overflowed the 240px card — later rows/hints spilled below
+            // the panel (e.g. "Tone glyphs on counters", "Nightfall").
+            vl.childControlHeight = true;
+            vl.childForceExpandWidth = true;
+            vl.childForceExpandHeight = false;
+
+            var sectionLabel = MakeText(contentRt, "SectionLabel", LedgeUITokens.MonoFont,
+                LedgeUITokens.SectionLabelSize, LedgeUITokens.InkDim, title.ToUpperInvariant());
+            sectionLabel.fontStyle = FontStyles.UpperCase;
+            sectionLabel.characterSpacing = 22f;
+            sectionLabel.alignment = TextAlignmentOptions.TopLeft;
+            AddLayoutHeight(sectionLabel.gameObject, 22f);
+
+            return contentRt;
+        }
+
+        // Builds the label/hint left side + a per-row hairline rule + a slot
+        // for the control. Returns the slot RectTransform so callers can drop
+        // their control into it.
+        private static RectTransform BuildRowShell(Transform parent, string label, string hint)
+        {
+            // Fixed-height band. The panel's VerticalLayoutGroup reads this
+            // height (LayoutElement) to stack rows; everything INSIDE the row
+            // is explicitly anchored — no nested HorizontalLayoutGroup /
+            // VerticalLayoutGroup — so TMP label/hint rects can't resolve to a
+            // bad default height and overlap the next row (the cp016 failure).
+            const float RowHeight = 58f;
+            // Right area reserved for the control slot, so the label/hint never
+            // run under the control.
+            const float ControlReserve = 196f;
+
+            var rowGo = new GameObject($"Row_{label}", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            var rowRt = (RectTransform)rowGo.transform;
+            rowRt.SetParent(parent, false);
+            AddLayoutHeight(rowGo, RowHeight);
+
+            var img = rowGo.GetComponent<Image>();
+            img.color = new Color(0f, 0f, 0f, 0f);
+            img.raycastTarget = false;
+
+            // Top hairline rule.
+            var rule = new GameObject("Rule", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            var ruleRt = (RectTransform)rule.transform;
+            ruleRt.SetParent(rowRt, false);
+            ruleRt.anchorMin = new Vector2(0f, 1f);
+            ruleRt.anchorMax = new Vector2(1f, 1f);
+            ruleRt.pivot = new Vector2(0.5f, 1f);
+            ruleRt.anchoredPosition = Vector2.zero;
+            ruleRt.sizeDelta = new Vector2(0f, 1f);
+            var ruleImg = rule.GetComponent<Image>();
+            ruleImg.color = LedgeUITokens.Rule;
+            ruleImg.raycastTarget = false;
+
+            bool hasHint = !string.IsNullOrEmpty(hint);
+
+            // Label — stretched from the left to ControlReserve short of the
+            // right edge, single line.
+            var labelText = MakeText(rowRt, "Label", LedgeUITokens.UIFont, 14f, LedgeUITokens.Ink, label);
+            labelText.alignment = TextAlignmentOptions.MidlineLeft;
+            labelText.textWrappingMode = TextWrappingModes.NoWrap;
+            var lrt = labelText.rectTransform;
+            lrt.anchorMin = new Vector2(0f, 1f);
+            lrt.anchorMax = new Vector2(1f, 1f);
+            lrt.pivot = new Vector2(0f, 1f);
+
+            if (hasHint)
+            {
+                // Label y[-30,-10] (20 tall) + hint y[-48,-32] (16 tall): a 38px
+                // block centred in the 58px band.
+                lrt.offsetMin = new Vector2(0f, -30f);
+                lrt.offsetMax = new Vector2(-ControlReserve, -10f);
+
+                var hintText = MakeText(rowRt, "Hint", LedgeUITokens.UIFont, 12f, LedgeUITokens.InkDim, hint);
+                hintText.alignment = TextAlignmentOptions.MidlineLeft;
+                hintText.textWrappingMode = TextWrappingModes.NoWrap;
+                var hrt = hintText.rectTransform;
+                hrt.anchorMin = new Vector2(0f, 1f);
+                hrt.anchorMax = new Vector2(1f, 1f);
+                hrt.pivot = new Vector2(0f, 1f);
+                hrt.offsetMin = new Vector2(0f, -48f);
+                hrt.offsetMax = new Vector2(-ControlReserve, -32f);
+            }
+            else
+            {
+                // Single label vertically centred in the band.
+                lrt.anchorMin = new Vector2(0f, 0.5f);
+                lrt.anchorMax = new Vector2(1f, 0.5f);
+                lrt.pivot = new Vector2(0f, 0.5f);
+                lrt.offsetMin = new Vector2(0f, -11f);
+                lrt.offsetMax = new Vector2(-ControlReserve, 11f);
+            }
+
+            // Control slot — fixed 180×44, anchored centre-right. Control
+            // builders parent here and anchor to its right edge.
+            var slotGo = new GameObject("ControlSlot", typeof(RectTransform));
+            var slotRt = (RectTransform)slotGo.transform;
+            slotRt.SetParent(rowRt, false);
+            slotRt.anchorMin = new Vector2(1f, 0.5f);
+            slotRt.anchorMax = new Vector2(1f, 0.5f);
+            slotRt.pivot = new Vector2(1f, 0.5f);
+            slotRt.anchoredPosition = Vector2.zero;
+            slotRt.sizeDelta = new Vector2(180f, 44f);
+            return slotRt;
+        }
+
+        // ── Toggle / Slider / Segmented controls ──────────────────────────
+
+        private static void BuildToggleRow(Transform parent, string label, string hint, bool initial, Action<bool> onChange)
+        {
+            var slot = BuildRowShell(parent, label, hint);
+            BuildToggle(slot, initial, onChange);
+        }
+
+        private static void BuildSliderRow(Transform parent, string label, string hint, float initial, Action<float> onChange)
+        {
+            var slot = BuildRowShell(parent, label, hint);
+            BuildKitSlider(slot, initial, onChange);
+        }
+
+        private static void BuildSegmentedRow(Transform parent, string label, string hint, string[] options, string initial, Action<string> onChange)
+        {
+            var slot = BuildRowShell(parent, label, hint);
+            BuildSegmented(slot, options, initial, onChange);
+        }
+
+        private static void BuildButtonRow(Transform parent, string label, string hint, string buttonText, Action onClick)
+        {
+            var slot = BuildRowShell(parent, label, hint);
+            // LedgeButton.Build takes UnityAction; System.Action wraps via a
+            // small adapter lambda so onClick? null still no-ops cleanly.
+            UnityEngine.Events.UnityAction wrapped = onClick != null ? () => onClick() : (UnityEngine.Events.UnityAction)null;
+            var btn = LedgeButton.Build(slot, buttonText, LedgeButton.Variant.Ghost, LedgeButton.Size.Sm, wrapped);
+            var rt = (RectTransform)btn.transform;
+            rt.anchorMin = new Vector2(1f, 0.5f);
+            rt.anchorMax = new Vector2(1f, 0.5f);
+            rt.pivot = new Vector2(1f, 0.5f);
+            rt.anchoredPosition = Vector2.zero;
+            rt.sizeDelta = new Vector2(90f, 28f);
+        }
+
+        private static void BuildToggle(Transform slot, bool initial, Action<bool> onChange)
+        {
+            var go = new GameObject("Toggle",
+                typeof(RectTransform), typeof(CanvasRenderer), typeof(Image),
+                typeof(Outline), typeof(Button));
+            var rt = (RectTransform)go.transform;
+            rt.SetParent(slot, false);
+            rt.anchorMin = new Vector2(1f, 0.5f);
+            rt.anchorMax = new Vector2(1f, 0.5f);
+            rt.pivot = new Vector2(1f, 0.5f);
+            rt.anchoredPosition = Vector2.zero;
+            rt.sizeDelta = new Vector2(44f, 24f);
+
+            var img = go.GetComponent<Image>();
+            var outline = go.GetComponent<Outline>();
+            outline.effectDistance = new Vector2(LedgeUITokens.HairlineWidth, -LedgeUITokens.HairlineWidth);
+
+            // Knob — child Image animated between left=2 and left=22.
+            var knobGo = new GameObject("Knob", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            var knobRt = (RectTransform)knobGo.transform;
+            knobRt.SetParent(rt, false);
+            knobRt.anchorMin = new Vector2(0f, 0.5f);
+            knobRt.anchorMax = new Vector2(0f, 0.5f);
+            knobRt.pivot = new Vector2(0.5f, 0.5f);
+            knobRt.sizeDelta = new Vector2(18f, 18f);
+            var knobImg = knobGo.GetComponent<Image>();
+            knobImg.sprite = GetDiscSprite();
+            knobImg.raycastTarget = false;
+
+            bool state = initial;
+            Action apply = () =>
+            {
+                if (state)
+                {
+                    img.color = new Color(LedgeUITokens.Accent.r, LedgeUITokens.Accent.g, LedgeUITokens.Accent.b, 0.22f);
+                    outline.effectColor = new Color(LedgeUITokens.Accent.r, LedgeUITokens.Accent.g, LedgeUITokens.Accent.b, 0.50f);
+                    knobImg.color = LedgeUITokens.Accent;
+                    knobRt.anchoredPosition = new Vector2(31f, 0f); // right = width - knobHalf - 2px = 44-9-2-2 ≈ 31
+                }
+                else
+                {
+                    img.color = new Color(8f / 255f, 10f / 255f, 22f / 255f, 0.70f);
+                    outline.effectColor = LedgeUITokens.PanelEdge2;
+                    knobImg.color = LedgeUITokens.InkDim;
+                    knobRt.anchoredPosition = new Vector2(11f, 0f); // left = knobHalf + 2px = 9+2 = 11
+                }
+            };
+            apply();
+
+            var btn = go.GetComponent<Button>();
+            btn.targetGraphic = img;
+            btn.onClick.AddListener(() =>
+            {
+                state = !state;
+                apply();
+                try { onChange?.Invoke(state); }
+                catch (Exception ex) { UnityEngine.Debug.LogError($"[settings:toggle] onChange threw: {ex}"); }
+            });
+        }
+
+        private static void BuildKitSlider(Transform slot, float initial, Action<float> onChange)
+        {
+            var go = new GameObject("Slider", typeof(RectTransform));
+            var rt = (RectTransform)go.transform;
+            rt.SetParent(slot, false);
+            rt.anchorMin = new Vector2(1f, 0.5f);
+            rt.anchorMax = new Vector2(1f, 0.5f);
+            rt.pivot = new Vector2(1f, 0.5f);
+            rt.anchoredPosition = Vector2.zero;
+            rt.sizeDelta = new Vector2(160f, 14f);
+
+            var bgGo = new GameObject("Background", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            var bgRt = (RectTransform)bgGo.transform;
+            bgRt.SetParent(rt, false);
+            bgRt.anchorMin = new Vector2(0f, 0.5f);
+            bgRt.anchorMax = new Vector2(1f, 0.5f);
+            bgRt.pivot = new Vector2(0.5f, 0.5f);
+            bgRt.sizeDelta = new Vector2(0f, 4f);
+            var bgImg = bgGo.GetComponent<Image>();
+            bgImg.color = new Color(8f / 255f, 10f / 255f, 22f / 255f, 0.70f);
+
+            var fillAreaGo = new GameObject("FillArea", typeof(RectTransform));
+            var faRt = (RectTransform)fillAreaGo.transform;
+            faRt.SetParent(rt, false);
+            faRt.anchorMin = new Vector2(0f, 0.5f);
+            faRt.anchorMax = new Vector2(1f, 0.5f);
+            faRt.pivot = new Vector2(0.5f, 0.5f);
+            faRt.sizeDelta = new Vector2(0f, 4f);
+
+            var fillGo = new GameObject("Fill", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            var fillRt = (RectTransform)fillGo.transform;
+            fillRt.SetParent(faRt, false);
+            fillRt.anchorMin = Vector2.zero; fillRt.anchorMax = Vector2.one;
+            fillRt.offsetMin = Vector2.zero; fillRt.offsetMax = Vector2.zero;
+            var fillImg = fillGo.GetComponent<Image>();
+            fillImg.color = new Color(LedgeUITokens.Accent.r, LedgeUITokens.Accent.g, LedgeUITokens.Accent.b, 0.55f);
+
+            var handleAreaGo = new GameObject("HandleArea", typeof(RectTransform));
+            var haRt = (RectTransform)handleAreaGo.transform;
+            haRt.SetParent(rt, false);
+            haRt.anchorMin = new Vector2(0f, 0.5f);
+            haRt.anchorMax = new Vector2(1f, 0.5f);
+            haRt.pivot = new Vector2(0.5f, 0.5f);
+            haRt.sizeDelta = new Vector2(0f, 14f);
+
+            var handleGo = new GameObject("Handle", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            var hRt = (RectTransform)handleGo.transform;
+            hRt.SetParent(haRt, false);
+            hRt.sizeDelta = new Vector2(14f, 14f);
+            var hImg = handleGo.GetComponent<Image>();
+            hImg.sprite = GetDiscSprite();
+            hImg.color = LedgeUITokens.Ink;
+
+            var slider = go.AddComponent<Slider>();
+            slider.fillRect = fillRt;
+            slider.handleRect = hRt;
+            slider.targetGraphic = hImg;
+            slider.direction = Slider.Direction.LeftToRight;
+            slider.minValue = 0f;
+            slider.maxValue = 1f;
+            slider.value = Mathf.Clamp01(initial);
+            slider.onValueChanged.AddListener(v =>
+            {
+                try { onChange?.Invoke(v); }
+                catch (Exception ex) { UnityEngine.Debug.LogError($"[settings:slider] onChange threw: {ex}"); }
+            });
+        }
+
+        private static void BuildSegmented(Transform slot, string[] options, string initial, Action<string> onChange)
+        {
+            var go = new GameObject("Segmented", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            var rt = (RectTransform)go.transform;
+            rt.SetParent(slot, false);
+            rt.anchorMin = new Vector2(1f, 0.5f);
+            rt.anchorMax = new Vector2(1f, 0.5f);
+            rt.pivot = new Vector2(1f, 0.5f);
+            rt.anchoredPosition = Vector2.zero;
+            rt.sizeDelta = new Vector2(180f, 30f);
+
+            var bg = go.GetComponent<Image>();
+            bg.color = new Color(8f / 255f, 10f / 255f, 22f / 255f, 0.60f);
+            bg.raycastTarget = false;
+
+            var hl = go.AddComponent<HorizontalLayoutGroup>();
+            hl.padding = new RectOffset(3, 3, 3, 3);
+            hl.spacing = 4f;
+            hl.childAlignment = TextAnchor.MiddleCenter;
+            hl.childControlWidth = true;
+            hl.childControlHeight = true;
+            hl.childForceExpandWidth = true;
+            hl.childForceExpandHeight = true;
+
+            var optionImages = new List<Image>(options.Length);
+            var optionLabels = new List<TMP_Text>(options.Length);
+
+            string state = initial;
+
+            void Apply()
+            {
+                for (int i = 0; i < options.Length; i++)
+                {
+                    bool active = options[i] == state;
+                    if (i < optionImages.Count && optionImages[i] != null)
+                        optionImages[i].color = active
+                            ? new Color(LedgeUITokens.Accent.r, LedgeUITokens.Accent.g, LedgeUITokens.Accent.b, 0.15f)
+                            : new Color(0f, 0f, 0f, 0f);
+                    if (i < optionLabels.Count && optionLabels[i] != null)
+                        optionLabels[i].color = active ? LedgeUITokens.Accent : LedgeUITokens.InkDim;
+                }
+            }
+
+            for (int i = 0; i < options.Length; i++)
+            {
+                int capturedI = i;
+                string captured = options[i];
+                var optGo = new GameObject($"Option_{captured}",
+                    typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Button));
+                optGo.transform.SetParent(rt, false);
+                var optImg = optGo.GetComponent<Image>();
+                optImg.color = new Color(0f, 0f, 0f, 0f);
+                optionImages.Add(optImg);
+
+                var optBtn = optGo.GetComponent<Button>();
+                optBtn.targetGraphic = optImg;
+                optBtn.onClick.AddListener(() =>
+                {
+                    if (state == captured) return;
+                    state = captured;
+                    Apply();
+                    try { onChange?.Invoke(state); }
+                    catch (Exception ex) { UnityEngine.Debug.LogError($"[settings:segmented] onChange threw: {ex}"); }
+                });
+
+                var optTextGo = new GameObject("Label", typeof(RectTransform));
+                optTextGo.transform.SetParent(optGo.transform, false);
+                var optTextRt = (RectTransform)optTextGo.transform;
+                optTextRt.anchorMin = Vector2.zero; optTextRt.anchorMax = Vector2.one;
+                optTextRt.offsetMin = Vector2.zero; optTextRt.offsetMax = Vector2.zero;
+                var optLabel = optTextGo.AddComponent<TextMeshProUGUI>();
+                optLabel.font = LedgeUITokens.UIFont;
+                optLabel.fontSize = 12f;
+                optLabel.fontStyle = FontStyles.Bold;
+                optLabel.color = LedgeUITokens.InkDim;
+                optLabel.text = captured;
+                optLabel.alignment = TextAlignmentOptions.Center;
+                optLabel.raycastTarget = false;
+                optionLabels.Add(optLabel);
+            }
+
+            Apply();
+        }
+
+        // ── Build helpers ─────────────────────────────────────────────────
+
+        private static TMP_Text MakeText(Transform parent, string name, TMP_FontAsset font,
+                                         float size, Color color, string text)
+        {
+            var go = new GameObject(name, typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var t = go.AddComponent<TextMeshProUGUI>();
+            t.font = font;
+            t.fontSize = size;
+            t.color = color;
+            t.text = text;
+            t.raycastTarget = false;
+            return t;
+        }
+
+        private static void AddLayoutHeight(GameObject go, float height)
+        {
+            var le = go.GetComponent<LayoutElement>() ?? go.AddComponent<LayoutElement>();
+            le.minHeight = height;
+            le.preferredHeight = height;
+        }
+
+        // Cached AA disc sprite for slider handle + toggle knob. Lazily
+        // generated; matches the small-radius round affordance the kit calls
+        // for without dragging in YouPanel's now-private circle generator.
+        private static Sprite _discSprite;
+        private static Sprite GetDiscSprite()
+        {
+            if (_discSprite != null) return _discSprite;
+            const int N = 64;
+            var tex = new Texture2D(N, N, TextureFormat.RGBA32, false)
+            {
+                filterMode = FilterMode.Bilinear,
+                wrapMode = TextureWrapMode.Clamp,
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            var px = new Color32[N * N];
+            float c = (N - 1) * 0.5f;
+            float r = c;
+            for (int y = 0; y < N; y++)
+                for (int x = 0; x < N; x++)
+                {
+                    float dx = x - c, dy = y - c;
+                    float d = Mathf.Sqrt(dx * dx + dy * dy);
+                    float a = Mathf.Clamp01(r - d);
+                    px[y * N + x] = new Color32(255, 255, 255, (byte)(a * 255f));
+                }
+            tex.SetPixels32(px);
+            tex.Apply(false, false);
+            _discSprite = Sprite.Create(tex, new Rect(0, 0, N, N), new Vector2(0.5f, 0.5f), 100f, 0, SpriteMeshType.FullRect);
+            _discSprite.hideFlags = HideFlags.HideAndDontSave;
+            return _discSprite;
+        }
+    }
+}

--- a/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeSettingsPanel.cs.meta
+++ b/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeSettingsPanel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2b9ecc0c0c23923469cbf60c162fb9f0

--- a/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeSetupPanel.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeSetupPanel.cs
@@ -1,0 +1,825 @@
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Magi.LedgeBoardGame.UI
+{
+    /// Player setup screen. Built from
+    /// `kit/ledge-board-game/project/ui/frame-setup.jsx` → SetupFrame:
+    /// two-column layout with an Identity panel on the left (display name +
+    /// "how others see you" preview) and a Board-skin grid on the right
+    /// (3×2 SkinSwatch cells + Back / Ready actions).
+    ///
+    /// Identity model (handoff v4 §0): players do NOT own a wheel color —
+    /// identity is name + board-skin signature. The skin grid is the
+    /// cosmetic pick. Real art is deferred; the six example skins below
+    /// (Nightfall / Ember / Verdant / Amethyst / Ashen / Tide) ship as
+    /// procedural radial gradients + an accent dot, the same data the kit
+    /// uses for its preview. Replace with texture lookups when the skin
+    /// catalog lands.
+    public class LedgeSetupPanel : MonoBehaviour
+    {
+        public readonly struct SkinDef
+        {
+            public readonly string Id;
+            public readonly string Name;
+            public readonly Color SkyInner;
+            public readonly Color SkyOuter;
+            public readonly Color Accent;
+
+            public SkinDef(string id, string name, Color skyInner, Color skyOuter, Color accent)
+            {
+                Id = id; Name = name; SkyInner = skyInner; SkyOuter = skyOuter; Accent = accent;
+            }
+        }
+
+        /// All 14 skins from kit `frame-setup.jsx` (F5 design pass).
+        /// Each entry mirrors {id, sky inner+outer, accent} verbatim.
+        public static readonly SkinDef[] DefaultSkins =
+        {
+            new SkinDef("nightfall", "Nightfall",
+                Hex("1B2755"), Hex("04050C"), Hex("8FB4FF")),
+            new SkinDef("ember",     "Ember",
+                Hex("3A1B16"), Hex("0C0503"), Hex("F2A24D")),
+            new SkinDef("verdant",   "Verdant",
+                Hex("143020"), Hex("03100A"), Hex("6FD89A")),
+            new SkinDef("amethyst",  "Amethyst",
+                Hex("2A1644"), Hex("0A0518"), Hex("C49AF0")),
+            new SkinDef("ashen",     "Ashen",
+                Hex("24262C"), Hex("08090C"), Hex("C8CCD6")),
+            new SkinDef("tide",      "Tide",
+                Hex("103040"), Hex("03101A"), Hex("5FC8E0")),
+            new SkinDef("rosewood",  "Rosewood",
+                Hex("3A1428"), Hex("0E040A"), Hex("E88FB4")),
+            new SkinDef("gilded",    "Gilded",
+                Hex("2E2410"), Hex("0C0902"), Hex("E8C66A")),
+            new SkinDef("glacier",   "Glacier",
+                Hex("16303A"), Hex("040E12"), Hex("A8E0E8")),
+            new SkinDef("obsidian",  "Obsidian",
+                Hex("16181E"), Hex("030305"), Hex("7A8294")),
+            new SkinDef("orchard",   "Orchard",
+                Hex("2A2E12"), Hex("090B02"), Hex("C2D86F")),
+            new SkinDef("dusk",      "Dusk",
+                Hex("34203A"), Hex("0C0512"), Hex("B98FD8")),
+            new SkinDef("coral",     "Coral",
+                Hex("3A1C18"), Hex("0E0503"), Hex("F0987A")),
+            new SkinDef("mistral",   "Mistral",
+                Hex("1E2838"), Hex("05090E"), Hex("9FB0C8")),
+        };
+
+        private GameObject _overlayGo;
+        private TMP_InputField _nameField;
+        private TMP_Text _previewLabel;
+        private RectTransform _previewChipBg;
+        private Image _previewChipSky;
+        private Image _previewChipAccent;
+        private TMP_Text _skinCountLabel;
+
+        private readonly List<SkinSwatchHandles> _swatches = new List<SkinSwatchHandles>();
+
+        private Action<string, string> _onReady;
+        private Action _onBack;
+
+        private string _selectedSkinId;
+        private string _displayName = "";
+
+        private struct SkinSwatchHandles
+        {
+            public string Id;
+            public Image ContainerBg;
+            public Outline ContainerOutline;
+            public TMP_Text NameLabel;
+            public TMP_Text ChosenLabel;
+        }
+
+        private void Awake() => EnsureBuilt();
+
+        public void EnsureBuilt()
+        {
+            if (_overlayGo != null) return;
+            BuildUi();
+            HideInternal();
+        }
+
+        // ── Public API ─────────────────────────────────────────────────────
+
+        /// Open the setup screen with an optional initial name + skin id.
+        /// Ready fires onReady(name, skinId); Back fires onBack.
+        public void Show(string initialName, string initialSkinId,
+                         Action<string, string> onReady, Action onBack = null)
+        {
+            EnsureBuilt();
+            _onReady = onReady;
+            _onBack = onBack;
+            _displayName = initialName ?? "";
+            if (_nameField != null) _nameField.SetTextWithoutNotify(_displayName);
+            _selectedSkinId = !string.IsNullOrEmpty(initialSkinId) && SkinExists(initialSkinId)
+                ? initialSkinId
+                : DefaultSkins[0].Id;
+            RefreshSelection();
+            _overlayGo.SetActive(true);
+            _overlayGo.transform.SetAsLastSibling();
+        }
+
+        public void Hide() => HideInternal();
+
+        public bool IsShowing => _overlayGo != null && _overlayGo.activeSelf;
+
+        [ContextMenu("Show Setup (Test)")]
+        private void ShowTestPreview()
+        {
+            Show("Aurelia", "nightfall",
+                (n, s) => UnityEngine.Debug.Log($"[setup] Ready name={n} skin={s} (test)"),
+                () => UnityEngine.Debug.Log("[setup] Back (test)"));
+        }
+
+        // ── Internals ─────────────────────────────────────────────────────
+
+        private bool SkinExists(string id)
+        {
+            for (int i = 0; i < DefaultSkins.Length; i++)
+                if (DefaultSkins[i].Id == id) return true;
+            return false;
+        }
+
+        private SkinDef ResolveSkin(string id)
+        {
+            for (int i = 0; i < DefaultSkins.Length; i++)
+                if (DefaultSkins[i].Id == id) return DefaultSkins[i];
+            return DefaultSkins[0];
+        }
+
+        private void HideInternal()
+        {
+            if (_overlayGo != null) _overlayGo.SetActive(false);
+        }
+
+        private void FireReady()
+        {
+            HideInternal();
+            try { _onReady?.Invoke(_displayName, _selectedSkinId); }
+            catch (Exception ex) { UnityEngine.Debug.LogError($"[setup] onReady threw: {ex}"); }
+        }
+
+        private void FireBack()
+        {
+            HideInternal();
+            try { _onBack?.Invoke(); }
+            catch (Exception ex) { UnityEngine.Debug.LogError($"[setup] onBack threw: {ex}"); }
+        }
+
+        private void RefreshSelection()
+        {
+            // Swatch tint pass.
+            foreach (var s in _swatches)
+            {
+                bool active = s.Id == _selectedSkinId;
+                if (s.ContainerBg != null)
+                    s.ContainerBg.color = active
+                        ? new Color(LedgeUITokens.Accent.r, LedgeUITokens.Accent.g, LedgeUITokens.Accent.b, 0.10f)
+                        : new Color(0f, 0f, 0f, 0f);
+                if (s.ContainerOutline != null)
+                    s.ContainerOutline.effectColor = active
+                        ? new Color(LedgeUITokens.Accent.r, LedgeUITokens.Accent.g, LedgeUITokens.Accent.b, 0.50f)
+                        : LedgeUITokens.PanelEdge;
+                if (s.NameLabel != null)
+                    s.NameLabel.color = active ? LedgeUITokens.Accent : LedgeUITokens.Ink;
+                if (s.ChosenLabel != null)
+                    s.ChosenLabel.gameObject.SetActive(active);
+            }
+
+            // Preview chip + label.
+            var skin = ResolveSkin(_selectedSkinId);
+            if (_previewChipSky != null)
+                _previewChipSky.sprite = GetRadialGradientSprite(skin.SkyInner, skin.SkyOuter);
+            if (_previewChipAccent != null) _previewChipAccent.color = skin.Accent;
+            if (_previewLabel != null)
+                _previewLabel.text = $"{(_displayName.Length == 0 ? "—" : _displayName)} · {skin.Name}";
+        }
+
+        // ── UI construction ───────────────────────────────────────────────
+
+        private void BuildUi()
+        {
+            var canvas = GetComponentInParent<Canvas>();
+            if (canvas == null) return;
+
+            _overlayGo = new GameObject("SetupOverlay", typeof(RectTransform));
+            var overlayRt = (RectTransform)_overlayGo.transform;
+            overlayRt.SetParent(canvas.transform, false);
+            overlayRt.anchorMin = Vector2.zero; overlayRt.anchorMax = Vector2.one;
+            overlayRt.offsetMin = Vector2.zero; overlayRt.offsetMax = Vector2.zero;
+            overlayRt.SetAsLastSibling();
+
+            // Solid canvas backdrop. Kit shows a faint board through a 60%
+            // scrim — we omit the live board for the same reason as title/
+            // tutorial and let the dream-canvas atmosphere read through any
+            // existing sibling backdrop.
+            var bgGo = new GameObject("Backdrop", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            var bgRt = (RectTransform)bgGo.transform;
+            bgRt.SetParent(overlayRt, false);
+            bgRt.anchorMin = Vector2.zero; bgRt.anchorMax = Vector2.one;
+            bgRt.offsetMin = Vector2.zero; bgRt.offsetMax = Vector2.zero;
+            var bgImg = bgGo.GetComponent<Image>();
+            // Fully opaque, matching the Settings and Tutorial full-takeover
+            // backdrops. At 0.95 the returning-player title (Ledge wordmark +
+            // nav) bled through when Setup opened over it (e.g. the Settings →
+            // Account sub-route); opaque removes the bleed while keeping the
+            // same dark dream-canvas tone.
+            bgImg.color = LedgeUITokens.Canvas;
+            bgImg.raycastTarget = true;
+
+            // Centered two-column grid host. The kit's grid is 340 + 28 + 520
+            // = 888 wide, with content vertically centered.
+            var gridGo = new GameObject("Grid", typeof(RectTransform));
+            var gridRt = (RectTransform)gridGo.transform;
+            gridRt.SetParent(overlayRt, false);
+            gridRt.anchorMin = new Vector2(0.5f, 0.5f);
+            gridRt.anchorMax = new Vector2(0.5f, 0.5f);
+            gridRt.pivot = new Vector2(0.5f, 0.5f);
+            gridRt.anchoredPosition = Vector2.zero;
+            gridRt.sizeDelta = new Vector2(888f, 600f);
+
+            var hl = gridGo.AddComponent<HorizontalLayoutGroup>();
+            hl.spacing = 28f;
+            hl.childAlignment = TextAnchor.UpperLeft;
+            // Control both axes so the panels' LayoutElement sizes (340x460 /
+            // 520x540) actually apply. With these false the group ignored the
+            // LayoutElements and both panels collapsed to their default ~100x100
+            // rect, which cascaded into every child (BOARD SKIN wrapping one
+            // letter per line, skin grid clipped, copy overlapping the name field).
+            hl.childControlWidth = true;
+            hl.childControlHeight = true;
+            hl.childForceExpandWidth = false;
+            hl.childForceExpandHeight = false;
+
+            BuildIdentityPanel(gridRt);
+            BuildSkinPanel(gridRt);
+        }
+
+        private void BuildIdentityPanel(Transform parent)
+        {
+            var hostGo = new GameObject("IdentityPanel", typeof(RectTransform), typeof(LayoutElement));
+            hostGo.transform.SetParent(parent, false);
+            var le = hostGo.GetComponent<LayoutElement>();
+            le.preferredWidth = 340f; le.minWidth = 340f;
+            le.preferredHeight = 460f; le.minHeight = 460f;
+
+            var glass = LedgeGlassPanel.Build(hostGo.transform, "Glass",
+                padding: new Vector2(30f, 32f));
+            var gRt = glass.GetComponent<RectTransform>();
+            gRt.anchorMin = Vector2.zero; gRt.anchorMax = Vector2.one;
+            gRt.offsetMin = Vector2.zero; gRt.offsetMax = Vector2.zero;
+
+            var col = new GameObject("Col", typeof(RectTransform));
+            var colRt = (RectTransform)col.transform;
+            colRt.SetParent(glass.Content, false);
+            colRt.anchorMin = Vector2.zero; colRt.anchorMax = Vector2.one;
+            colRt.offsetMin = Vector2.zero; colRt.offsetMax = Vector2.zero;
+            var vl = col.AddComponent<VerticalLayoutGroup>();
+            vl.spacing = 0f;
+            vl.childAlignment = TextAnchor.UpperLeft;
+            vl.childControlWidth = true;
+            // Control height so each row's declared LayoutElement height sizes it;
+            // with it false the rows kept their default rect height and the copy
+            // overlapped the display-name label/field.
+            vl.childControlHeight = true;
+            vl.childForceExpandWidth = true;
+            vl.childForceExpandHeight = false;
+
+            var section = MakeText(colRt, "Section", LedgeUITokens.MonoFont,
+                LedgeUITokens.SectionLabelSize, LedgeUITokens.InkDim, "YOUR IDENTITY");
+            section.fontStyle = FontStyles.UpperCase;
+            section.characterSpacing = 22f;
+            AddLayoutHeight(section.gameObject, 14f);
+            AddSpacer(colRt, 16f);
+
+            var copy = MakeText(colRt, "Copy", LedgeUITokens.DisplayFont, 28f, LedgeUITokens.Ink,
+                "You don't own a color — your board is your signature.");
+            copy.fontStyle = FontStyles.Italic;
+            copy.alignment = TextAlignmentOptions.TopLeft;
+            copy.textWrappingMode = TextWrappingModes.Normal;
+            AddLayoutHeight(copy.gameObject, 96f);
+            AddSpacer(colRt, 22f);
+
+            var nameSection = MakeText(colRt, "NameSection", LedgeUITokens.MonoFont,
+                LedgeUITokens.SectionLabelSize, LedgeUITokens.InkDim, "DISPLAY NAME");
+            nameSection.fontStyle = FontStyles.UpperCase;
+            nameSection.characterSpacing = 22f;
+            AddLayoutHeight(nameSection.gameObject, 14f);
+            AddSpacer(colRt, 7f);
+
+            _nameField = BuildInputField(colRt, _displayName);
+            _nameField.onValueChanged.AddListener(v =>
+            {
+                _displayName = v ?? "";
+                if (_previewLabel != null)
+                {
+                    var skin = ResolveSkin(_selectedSkinId);
+                    _previewLabel.text = $"{(_displayName.Length == 0 ? "—" : _displayName)} · {skin.Name}";
+                }
+            });
+            AddSpacer(colRt, 24f);
+
+            BuildPreviewBlock(colRt);
+        }
+
+        private void BuildPreviewBlock(Transform parent)
+        {
+            var rowGo = new GameObject("Preview",
+                typeof(RectTransform), typeof(CanvasRenderer), typeof(Image),
+                typeof(Outline), typeof(HorizontalLayoutGroup));
+            rowGo.transform.SetParent(parent, false);
+            AddLayoutHeight(rowGo, 76f);
+
+            var bg = rowGo.GetComponent<Image>();
+            bg.color = new Color(8f / 255f, 10f / 255f, 22f / 255f, 0.40f);
+            bg.raycastTarget = false;
+            var outline = rowGo.GetComponent<Outline>();
+            outline.effectColor = LedgeUITokens.PanelEdge;
+            outline.effectDistance = new Vector2(LedgeUITokens.HairlineWidth, -LedgeUITokens.HairlineWidth);
+
+            var hl = rowGo.GetComponent<HorizontalLayoutGroup>();
+            hl.padding = new RectOffset(16, 16, 14, 14);
+            hl.spacing = 12f;
+            hl.childAlignment = TextAnchor.MiddleLeft;
+            // Control both axes so the chip (40x44) and the text column size
+            // from their layout data instead of collapsing to default rects.
+            hl.childControlWidth = true;
+            hl.childControlHeight = true;
+            hl.childForceExpandWidth = false;
+            hl.childForceExpandHeight = false;
+
+            // Skin chip (40×44, kit dims): radial gradient bg + small accent
+            // hex hint approximated as a colored disc (Unity UI can't draw
+            // arbitrary polygons; the kit's hex motif degrades to a dot here).
+            var chipGo = new GameObject("Chip", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Outline), typeof(LayoutElement));
+            chipGo.transform.SetParent(rowGo.transform, false);
+            _previewChipBg = (RectTransform)chipGo.transform;
+            _previewChipSky = chipGo.GetComponent<Image>();
+            _previewChipSky.color = Color.white;
+            _previewChipSky.raycastTarget = false;
+            var chipOutline = chipGo.GetComponent<Outline>();
+            chipOutline.effectColor = LedgeUITokens.PanelEdge2;
+            chipOutline.effectDistance = new Vector2(LedgeUITokens.HairlineWidth, -LedgeUITokens.HairlineWidth);
+            var chipLe = chipGo.GetComponent<LayoutElement>();
+            chipLe.minWidth = 40f; chipLe.preferredWidth = 40f;
+            chipLe.minHeight = 44f; chipLe.preferredHeight = 44f;
+
+            // Accent dot (centered)
+            var dotGo = new GameObject("AccentDot", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            dotGo.transform.SetParent(chipGo.transform, false);
+            var dotRt = (RectTransform)dotGo.transform;
+            dotRt.anchorMin = new Vector2(0.5f, 0.5f);
+            dotRt.anchorMax = new Vector2(0.5f, 0.5f);
+            dotRt.pivot = new Vector2(0.5f, 0.5f);
+            dotRt.sizeDelta = new Vector2(16f, 16f);
+            _previewChipAccent = dotGo.GetComponent<Image>();
+            _previewChipAccent.sprite = GetDiscSprite();
+            _previewChipAccent.color = Color.white;
+            _previewChipAccent.raycastTarget = false;
+
+            // Right side: label + "HOW OTHERS SEE YOU" caption.
+            var textColGo = new GameObject("TextCol", typeof(RectTransform), typeof(VerticalLayoutGroup));
+            textColGo.transform.SetParent(rowGo.transform, false);
+            var textVl = textColGo.GetComponent<VerticalLayoutGroup>();
+            textVl.spacing = 3f;
+            textVl.childAlignment = TextAnchor.MiddleLeft;
+            textVl.childControlWidth = true;
+            // Control height so the label + caption stack by their declared
+            // heights rather than overlapping at a default rect height.
+            textVl.childControlHeight = true;
+            textVl.childForceExpandWidth = true;
+            textVl.childForceExpandHeight = false;
+            // Fill the row's remaining width beside the chip.
+            var textColLe = textColGo.AddComponent<LayoutElement>();
+            textColLe.flexibleWidth = 1f;
+
+            _previewLabel = MakeText(textColGo.transform, "Label", LedgeUITokens.UIFont, 13f, LedgeUITokens.Ink, "—");
+            _previewLabel.fontStyle = FontStyles.Bold;
+            _previewLabel.alignment = TextAlignmentOptions.MidlineLeft;
+            AddLayoutHeight(_previewLabel.gameObject, 18f);
+
+            var caption = MakeText(textColGo.transform, "Caption", LedgeUITokens.MonoFont, 9.5f, LedgeUITokens.InkDim, "HOW OTHERS SEE YOU");
+            caption.fontStyle = FontStyles.UpperCase;
+            caption.characterSpacing = 16f;
+            caption.alignment = TextAlignmentOptions.MidlineLeft;
+            AddLayoutHeight(caption.gameObject, 12f);
+        }
+
+        private void BuildSkinPanel(Transform parent)
+        {
+            var hostGo = new GameObject("SkinPanel", typeof(RectTransform), typeof(LayoutElement));
+            hostGo.transform.SetParent(parent, false);
+            var le = hostGo.GetComponent<LayoutElement>();
+            le.preferredWidth = 520f; le.minWidth = 520f;
+            // Taller than the identity panel so the kit's 14-skin grid has
+            // breathing room. Excess vertical is absorbed by the ScrollRect
+            // we wrap around the grid below.
+            le.preferredHeight = 540f; le.minHeight = 540f;
+
+            var glass = LedgeGlassPanel.Build(hostGo.transform, "Glass",
+                padding: new Vector2(26f, 24f));
+            var gRt = glass.GetComponent<RectTransform>();
+            gRt.anchorMin = Vector2.zero; gRt.anchorMax = Vector2.one;
+            gRt.offsetMin = Vector2.zero; gRt.offsetMax = Vector2.zero;
+
+            var col = new GameObject("Col", typeof(RectTransform));
+            var colRt = (RectTransform)col.transform;
+            colRt.SetParent(glass.Content, false);
+            colRt.anchorMin = Vector2.zero; colRt.anchorMax = Vector2.one;
+            colRt.offsetMin = Vector2.zero; colRt.offsetMax = Vector2.zero;
+            var vl = col.AddComponent<VerticalLayoutGroup>();
+            vl.spacing = 18f;
+            vl.childAlignment = TextAnchor.UpperLeft;
+            vl.childControlWidth = true;
+            // Control height so the header / scroll / actions rows size from
+            // their declared heights instead of collapsing.
+            vl.childControlHeight = true;
+            vl.childForceExpandWidth = true;
+            vl.childForceExpandHeight = false;
+
+            // Header row: SectionLabel + "N OF M" mono.
+            var headerGo = new GameObject("Header",
+                typeof(RectTransform), typeof(HorizontalLayoutGroup));
+            headerGo.transform.SetParent(colRt, false);
+            var headerHl = headerGo.GetComponent<HorizontalLayoutGroup>();
+            headerHl.spacing = 8f;
+            headerHl.childAlignment = TextAnchor.LowerLeft;
+            headerHl.childControlWidth = true;
+            // Control height so the label doesn't keep a default rect height
+            // (which is what made "BOARD SKIN" stack vertically once its width
+            // also collapsed); the row height stays pinned by AddLayoutHeight.
+            headerHl.childControlHeight = true;
+            headerHl.childForceExpandWidth = true;
+            headerHl.childForceExpandHeight = false;
+            AddLayoutHeight(headerGo, 14f);
+
+            var headerLabel = MakeText(headerGo.transform, "Section", LedgeUITokens.MonoFont,
+                LedgeUITokens.SectionLabelSize, LedgeUITokens.InkDim, "BOARD SKIN");
+            headerLabel.fontStyle = FontStyles.UpperCase;
+            headerLabel.characterSpacing = 22f;
+            headerLabel.alignment = TextAlignmentOptions.BottomLeft;
+            var headerLabelLe = headerLabel.gameObject.AddComponent<LayoutElement>();
+            headerLabelLe.flexibleWidth = 1f;
+
+            // F5 caption: the kit now ships all 14 skins so this reads as
+            // a static "14 SKINS" rather than the old "N OF 14" rollout
+            // counter.
+            _skinCountLabel = MakeText(headerGo.transform, "Count", LedgeUITokens.MonoFont, 9.5f,
+                LedgeUITokens.InkMute, "14 SKINS");
+            _skinCountLabel.fontStyle = FontStyles.UpperCase;
+            _skinCountLabel.characterSpacing = 14f;
+            _skinCountLabel.alignment = TextAlignmentOptions.BottomRight;
+            var countLe = _skinCountLabel.gameObject.AddComponent<LayoutElement>();
+            countLe.preferredWidth = 70f;
+            countLe.minWidth = 70f;
+
+            // Scrollable 3-col grid. With 14 swatches at ~145×130 the
+            // content runs ~5 rows tall (~720); the viewport is bounded so
+            // the panel stays compact and the user scrolls through the
+            // remaining skins.
+            var scrollGo = new GameObject("ScrollHost",
+                typeof(RectTransform), typeof(ScrollRect), typeof(Image));
+            scrollGo.transform.SetParent(colRt, false);
+            var scrollImg = scrollGo.GetComponent<Image>();
+            scrollImg.color = new Color(0f, 0f, 0f, 0f);
+            scrollImg.raycastTarget = true; // captures wheel events
+            AddLayoutHeight(scrollGo, 360f);
+
+            var viewportGo = new GameObject("Viewport",
+                typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(RectMask2D));
+            viewportGo.transform.SetParent(scrollGo.transform, false);
+            var viewportRt = (RectTransform)viewportGo.transform;
+            viewportRt.anchorMin = Vector2.zero; viewportRt.anchorMax = Vector2.one;
+            viewportRt.offsetMin = Vector2.zero; viewportRt.offsetMax = Vector2.zero;
+            var viewportImg = viewportGo.GetComponent<Image>();
+            viewportImg.color = new Color(0f, 0f, 0f, 0f);
+            viewportImg.raycastTarget = true;
+
+            var gridGo = new GameObject("SkinGrid",
+                typeof(RectTransform), typeof(GridLayoutGroup), typeof(ContentSizeFitter));
+            gridGo.transform.SetParent(viewportGo.transform, false);
+            var gridRt = (RectTransform)gridGo.transform;
+            gridRt.anchorMin = new Vector2(0f, 1f);
+            gridRt.anchorMax = new Vector2(1f, 1f);
+            gridRt.pivot = new Vector2(0.5f, 1f);
+            gridRt.anchoredPosition = Vector2.zero;
+            gridRt.sizeDelta = Vector2.zero;
+
+            var grid = gridGo.GetComponent<GridLayoutGroup>();
+            grid.cellSize = new Vector2(145f, 130f);
+            grid.spacing = new Vector2(14f, 14f);
+            grid.childAlignment = TextAnchor.UpperLeft;
+            grid.startCorner = GridLayoutGroup.Corner.UpperLeft;
+            grid.startAxis = GridLayoutGroup.Axis.Horizontal;
+            grid.constraint = GridLayoutGroup.Constraint.FixedColumnCount;
+            grid.constraintCount = 3;
+
+            var fitter = gridGo.GetComponent<ContentSizeFitter>();
+            fitter.horizontalFit = ContentSizeFitter.FitMode.Unconstrained;
+            fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
+
+            var scroll = scrollGo.GetComponent<ScrollRect>();
+            scroll.content = gridRt;
+            scroll.viewport = viewportRt;
+            scroll.horizontal = false;
+            scroll.vertical = true;
+            scroll.movementType = ScrollRect.MovementType.Clamped;
+            scroll.scrollSensitivity = 30f;
+
+            _swatches.Clear();
+            for (int i = 0; i < DefaultSkins.Length; i++)
+            {
+                _swatches.Add(BuildSwatch(gridGo.transform, DefaultSkins[i]));
+            }
+
+            // Actions row right-aligned.
+            var actionsGo = new GameObject("Actions",
+                typeof(RectTransform), typeof(HorizontalLayoutGroup));
+            actionsGo.transform.SetParent(colRt, false);
+            var actionsHl = actionsGo.GetComponent<HorizontalLayoutGroup>();
+            actionsHl.spacing = 12f;
+            actionsHl.childAlignment = TextAnchor.MiddleRight;
+            // Control width so the buttons' preferred widths apply (with it off
+            // they collapsed to a default rect); keep force-expand-height off so
+            // the buttons hold their ~48px height and this row doesn't claim the
+            // column's vertical slack and balloon the buttons.
+            actionsHl.childControlWidth = true;
+            actionsHl.childControlHeight = true;
+            actionsHl.childForceExpandWidth = false;
+            actionsHl.childForceExpandHeight = false;
+            AddLayoutHeight(actionsGo, 52f);
+
+            var backBtn = LedgeButton.Build(actionsGo.transform, "Back", LedgeButton.Variant.Ghost, LedgeButton.Size.Lg,
+                FireBack);
+            var backLe = backBtn.gameObject.AddComponent<LayoutElement>();
+            backLe.preferredWidth = 110f; backLe.minWidth = 90f;
+            backLe.preferredHeight = 48f; backLe.minHeight = 44f;
+
+            var readyBtn = LedgeButton.Build(actionsGo.transform, "Ready", LedgeButton.Variant.Primary, LedgeButton.Size.Lg,
+                FireReady);
+            var readyLe = readyBtn.gameObject.AddComponent<LayoutElement>();
+            readyLe.preferredWidth = 130f; readyLe.minWidth = 110f;
+            readyLe.preferredHeight = 48f; readyLe.minHeight = 44f;
+        }
+
+        private SkinSwatchHandles BuildSwatch(Transform parent, SkinDef skin)
+        {
+            var containerGo = new GameObject($"Swatch_{skin.Id}",
+                typeof(RectTransform), typeof(CanvasRenderer), typeof(Image),
+                typeof(Outline), typeof(Button));
+            containerGo.transform.SetParent(parent, false);
+
+            var containerBg = containerGo.GetComponent<Image>();
+            containerBg.color = new Color(0f, 0f, 0f, 0f);
+            var containerOutline = containerGo.GetComponent<Outline>();
+            containerOutline.effectColor = LedgeUITokens.PanelEdge;
+            containerOutline.effectDistance = new Vector2(LedgeUITokens.HairlineWidth, -LedgeUITokens.HairlineWidth);
+
+            // Sky preview area (96 tall × full width, top-anchored).
+            var skyGo = new GameObject("Sky", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Outline));
+            skyGo.transform.SetParent(containerGo.transform, false);
+            var skyRt = (RectTransform)skyGo.transform;
+            skyRt.anchorMin = new Vector2(0f, 1f);
+            skyRt.anchorMax = new Vector2(1f, 1f);
+            skyRt.pivot = new Vector2(0.5f, 1f);
+            skyRt.offsetMin = new Vector2(4f, -4f - 96f);
+            skyRt.offsetMax = new Vector2(-4f, -4f);
+            var skyImg = skyGo.GetComponent<Image>();
+            skyImg.sprite = GetRadialGradientSprite(skin.SkyInner, skin.SkyOuter);
+            skyImg.color = Color.white;
+            skyImg.raycastTarget = false;
+            var skyOutline = skyGo.GetComponent<Outline>();
+            skyOutline.effectColor = LedgeUITokens.PanelEdge2;
+            skyOutline.effectDistance = new Vector2(LedgeUITokens.HairlineWidth, -LedgeUITokens.HairlineWidth);
+
+            // Accent hex hint approximated as a centered disc.
+            var dotGo = new GameObject("AccentDot", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            dotGo.transform.SetParent(skyGo.transform, false);
+            var dotRt = (RectTransform)dotGo.transform;
+            dotRt.anchorMin = new Vector2(0.5f, 0.5f);
+            dotRt.anchorMax = new Vector2(0.5f, 0.5f);
+            dotRt.pivot = new Vector2(0.5f, 0.5f);
+            dotRt.sizeDelta = new Vector2(34f, 34f);
+            var dotImg = dotGo.GetComponent<Image>();
+            dotImg.sprite = GetDiscSprite();
+            dotImg.color = new Color(skin.Accent.r, skin.Accent.g, skin.Accent.b, 0.85f);
+            dotImg.raycastTarget = false;
+
+            // Bottom name + chosen caption row.
+            var bottomGo = new GameObject("Bottom", typeof(RectTransform));
+            bottomGo.transform.SetParent(containerGo.transform, false);
+            var bottomRt = (RectTransform)bottomGo.transform;
+            bottomRt.anchorMin = new Vector2(0f, 0f);
+            bottomRt.anchorMax = new Vector2(1f, 0f);
+            bottomRt.pivot = new Vector2(0.5f, 0f);
+            bottomRt.offsetMin = new Vector2(8f, 6f);
+            bottomRt.offsetMax = new Vector2(-8f, 6f + 24f);
+
+            var bottomHl = bottomGo.AddComponent<HorizontalLayoutGroup>();
+            bottomHl.spacing = 6f;
+            bottomHl.childAlignment = TextAnchor.MiddleLeft;
+            bottomHl.childControlWidth = true;
+            bottomHl.childControlHeight = false;
+            bottomHl.childForceExpandWidth = false;
+            bottomHl.childForceExpandHeight = false;
+
+            var nameLabel = MakeText(bottomRt, "Name", LedgeUITokens.UIFont, 12f, LedgeUITokens.Ink, skin.Name);
+            nameLabel.fontStyle = FontStyles.Bold;
+            nameLabel.alignment = TextAlignmentOptions.MidlineLeft;
+            var nameLe = nameLabel.gameObject.AddComponent<LayoutElement>();
+            nameLe.flexibleWidth = 1f;
+
+            var chosenLabel = MakeText(bottomRt, "Chosen", LedgeUITokens.MonoFont, 8f, LedgeUITokens.Accent, "CHOSEN");
+            chosenLabel.fontStyle = FontStyles.UpperCase;
+            chosenLabel.characterSpacing = 16f;
+            chosenLabel.alignment = TextAlignmentOptions.MidlineRight;
+            var chosenLe = chosenLabel.gameObject.AddComponent<LayoutElement>();
+            chosenLe.preferredWidth = 50f;
+            chosenLe.minWidth = 50f;
+            chosenLabel.gameObject.SetActive(false);
+
+            // Click → select.
+            var btn = containerGo.GetComponent<Button>();
+            btn.targetGraphic = containerBg;
+            string capturedId = skin.Id;
+            btn.onClick.AddListener(() =>
+            {
+                if (_selectedSkinId == capturedId) return;
+                _selectedSkinId = capturedId;
+                RefreshSelection();
+            });
+
+            return new SkinSwatchHandles
+            {
+                Id = skin.Id,
+                ContainerBg = containerBg,
+                ContainerOutline = containerOutline,
+                NameLabel = nameLabel,
+                ChosenLabel = chosenLabel,
+            };
+        }
+
+        private static TMP_InputField BuildInputField(Transform parent, string initial)
+        {
+            var go = new GameObject("NameField",
+                typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Outline));
+            go.transform.SetParent(parent, false);
+            var bg = go.GetComponent<Image>();
+            bg.color = new Color(8f / 255f, 10f / 255f, 22f / 255f, 0.55f);
+            var outline = go.GetComponent<Outline>();
+            outline.effectColor = LedgeUITokens.PanelEdge2;
+            outline.effectDistance = new Vector2(LedgeUITokens.HairlineWidth, -LedgeUITokens.HairlineWidth);
+            AddLayoutHeight(go, 42f);
+
+            var textArea = new GameObject("TextArea", typeof(RectTransform), typeof(RectMask2D));
+            var taRt = (RectTransform)textArea.transform;
+            taRt.SetParent(go.transform, false);
+            taRt.anchorMin = Vector2.zero; taRt.anchorMax = Vector2.one;
+            taRt.offsetMin = new Vector2(14f, 4f);
+            taRt.offsetMax = new Vector2(-14f, -4f);
+
+            var phGo = new GameObject("Placeholder", typeof(RectTransform));
+            var phRt = (RectTransform)phGo.transform;
+            phRt.SetParent(taRt, false);
+            phRt.anchorMin = Vector2.zero; phRt.anchorMax = Vector2.one;
+            phRt.offsetMin = Vector2.zero; phRt.offsetMax = Vector2.zero;
+            var ph = phGo.AddComponent<TextMeshProUGUI>();
+            ph.text = "Aurelia";
+            ph.font = LedgeUITokens.UIFont;
+            ph.fontSize = 16f;
+            ph.color = LedgeUITokens.InkMute;
+            ph.fontStyle = FontStyles.Italic;
+            ph.alignment = TextAlignmentOptions.MidlineLeft;
+            ph.raycastTarget = false;
+
+            var txGo = new GameObject("Text", typeof(RectTransform));
+            var txRt = (RectTransform)txGo.transform;
+            txRt.SetParent(taRt, false);
+            txRt.anchorMin = Vector2.zero; txRt.anchorMax = Vector2.one;
+            txRt.offsetMin = Vector2.zero; txRt.offsetMax = Vector2.zero;
+            var txt = txGo.AddComponent<TextMeshProUGUI>();
+            txt.font = LedgeUITokens.UIFont;
+            txt.fontSize = 16f;
+            txt.color = LedgeUITokens.Ink;
+            txt.alignment = TextAlignmentOptions.MidlineLeft;
+            txt.raycastTarget = false;
+
+            var input = go.AddComponent<TMP_InputField>();
+            input.targetGraphic = bg;
+            input.textViewport = taRt;
+            input.textComponent = txt;
+            input.placeholder = ph;
+            input.fontAsset = LedgeUITokens.UIFont;
+            input.pointSize = 16f;
+            input.lineType = TMP_InputField.LineType.SingleLine;
+            input.text = initial ?? "";
+            return input;
+        }
+
+        // ── Build helpers ─────────────────────────────────────────────────
+
+        private static TMP_Text MakeText(Transform parent, string name, TMP_FontAsset font,
+                                         float size, Color color, string text)
+        {
+            var go = new GameObject(name, typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var t = go.AddComponent<TextMeshProUGUI>();
+            t.font = font;
+            t.fontSize = size;
+            t.color = color;
+            t.text = text;
+            t.raycastTarget = false;
+            return t;
+        }
+
+        private static void AddLayoutHeight(GameObject go, float height)
+        {
+            var le = go.GetComponent<LayoutElement>() ?? go.AddComponent<LayoutElement>();
+            le.minHeight = height;
+            le.preferredHeight = height;
+        }
+
+        private static void AddSpacer(Transform parent, float height)
+        {
+            var go = new GameObject("Spacer", typeof(RectTransform), typeof(LayoutElement));
+            go.transform.SetParent(parent, false);
+            var le = go.GetComponent<LayoutElement>();
+            le.minHeight = height; le.preferredHeight = height;
+        }
+
+        private static Color Hex(string h)
+        {
+            ColorUtility.TryParseHtmlString("#" + h, out var c);
+            return c;
+        }
+
+        // ── Sprite generators ─────────────────────────────────────────────
+
+        private static readonly Dictionary<(Color, Color), Sprite> _radialCache = new Dictionary<(Color, Color), Sprite>();
+        private static Sprite GetRadialGradientSprite(Color inner, Color outer)
+        {
+            var key = (inner, outer);
+            if (_radialCache.TryGetValue(key, out var s) && s != null) return s;
+            const int N = 128;
+            var tex = new Texture2D(N, N, TextureFormat.RGBA32, false)
+            {
+                filterMode = FilterMode.Bilinear,
+                wrapMode = TextureWrapMode.Clamp,
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            var px = new Color32[N * N];
+            // Kit specifies the radial focus at 50% 40% — slightly above center.
+            float cx = (N - 1) * 0.5f;
+            float cy = (N - 1) * 0.40f;
+            float maxR = Mathf.Sqrt(cx * cx + (N - 1 - cy) * (N - 1 - cy));
+            for (int y = 0; y < N; y++)
+                for (int x = 0; x < N; x++)
+                {
+                    float dx = x - cx, dy = y - cy;
+                    float d = Mathf.Sqrt(dx * dx + dy * dy);
+                    float t = Mathf.Clamp01(d / maxR);
+                    Color c = Color.Lerp(inner, outer, t);
+                    px[y * N + x] = c;
+                }
+            tex.SetPixels32(px);
+            tex.Apply(false, false);
+            var sprite = Sprite.Create(tex, new Rect(0, 0, N, N), new Vector2(0.5f, 0.5f), 100f, 0, SpriteMeshType.FullRect);
+            sprite.hideFlags = HideFlags.HideAndDontSave;
+            _radialCache[key] = sprite;
+            return sprite;
+        }
+
+        private static Sprite _discSprite;
+        private static Sprite GetDiscSprite()
+        {
+            if (_discSprite != null) return _discSprite;
+            const int N = 64;
+            var tex = new Texture2D(N, N, TextureFormat.RGBA32, false)
+            {
+                filterMode = FilterMode.Bilinear,
+                wrapMode = TextureWrapMode.Clamp,
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            var px = new Color32[N * N];
+            float c = (N - 1) * 0.5f;
+            float r = c;
+            for (int y = 0; y < N; y++)
+                for (int x = 0; x < N; x++)
+                {
+                    float dx = x - c, dy = y - c;
+                    float d = Mathf.Sqrt(dx * dx + dy * dy);
+                    float a = Mathf.Clamp01(r - d);
+                    px[y * N + x] = new Color32(255, 255, 255, (byte)(a * 255f));
+                }
+            tex.SetPixels32(px);
+            tex.Apply(false, false);
+            _discSprite = Sprite.Create(tex, new Rect(0, 0, N, N), new Vector2(0.5f, 0.5f), 100f, 0, SpriteMeshType.FullRect);
+            _discSprite.hideFlags = HideFlags.HideAndDontSave;
+            return _discSprite;
+        }
+    }
+}

--- a/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeSetupPanel.cs.meta
+++ b/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeSetupPanel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0f5392b5966239745b73eaf1567a2620

--- a/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeTitlePanel.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeTitlePanel.cs
@@ -1,0 +1,317 @@
+using System;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Magi.LedgeBoardGame.UI
+{
+    /// Title / landing screen. Built from
+    /// `kit/ledge-board-game/project/ui/frame-title.jsx` → TitleFrame:
+    /// hero board fading into a bottom scrim, giant Fraunces italic "Ledge"
+    /// logotype + mono tagline, action row (Play / Practice / How to play /
+    /// Settings), version footer.
+    ///
+    /// Hero board is intentionally omitted in this port — the gameplay
+    /// `LedgeDreamCanvas` backdrop sits on the same lobby canvas and
+    /// provides the starfield + gradient atmosphere. Reintroducing the
+    /// scaled board would need either a live BoardPresenter or a sprite
+    /// snapshot; deferred.
+    ///
+    /// Spawned by LedgeLobbyBootstrap before the lobby main panel becomes
+    /// visible. Closing the title (Play / Practice) hands off to the lobby
+    /// with the corresponding tab pre-selected.
+    public class LedgeTitlePanel : MonoBehaviour
+    {
+        [Tooltip("Version string rendered in the bottom-right footer.")]
+        [SerializeField] private string versionString = "v0.6 · MAGI AGI";
+
+        private GameObject _overlayGo;
+        private Action _onPlay;
+        private Action _onPractice;
+        private Action _onHowToPlay;
+        private Action _onSettings;
+
+        // F6 first-launch nudge: warm accent halo pulses on the
+        // How-to-play button until the user clicks it (or moves on). The
+        // pulse is opt-in via Show's highlightHowToPlay param so subsequent
+        // sessions get a clean title.
+        private LedgeButton _howBtn;
+        private Outline _howGlow;
+        private bool _highlightHowToPlay;
+        private float _highlightPhase;
+
+        private static Sprite _verticalScrimSprite;
+
+        private void Awake() => EnsureBuilt();
+
+        public void EnsureBuilt()
+        {
+            if (_overlayGo != null) return;
+            BuildUi();
+            HideInternal();
+        }
+
+        // ── Public API ─────────────────────────────────────────────────────
+
+        public void Show(Action onPlay, Action onPractice, Action onHowToPlay = null,
+                         Action onSettings = null, bool highlightHowToPlay = false)
+        {
+            EnsureBuilt();
+            _onPlay = onPlay;
+            _onPractice = onPractice;
+            _onHowToPlay = onHowToPlay;
+            _onSettings = onSettings;
+            _highlightHowToPlay = highlightHowToPlay;
+            _highlightPhase = 0f;
+            if (_howGlow != null && !highlightHowToPlay)
+                _howGlow.effectColor = new Color(0f, 0f, 0f, 0f);
+            _overlayGo.SetActive(true);
+        }
+
+        public void Hide() => HideInternal();
+
+        [ContextMenu("Show Title (Test)")]
+        private void ShowTestPreview()
+        {
+            Show(
+                onPlay: () => UnityEngine.Debug.Log("[title] Play (test)"),
+                onPractice: () => UnityEngine.Debug.Log("[title] Practice (test)"),
+                onHowToPlay: () => UnityEngine.Debug.Log("[title] How to play (test)"),
+                onSettings: () => UnityEngine.Debug.Log("[title] Settings (test)"));
+        }
+
+        // ── Internals ─────────────────────────────────────────────────────
+
+        private void HideInternal()
+        {
+            if (_overlayGo != null) _overlayGo.SetActive(false);
+        }
+
+        private void FireAndHide(Action callback)
+        {
+            HideInternal();
+            try { callback?.Invoke(); }
+            catch (Exception ex) { UnityEngine.Debug.LogError($"[title] callback threw: {ex}"); }
+        }
+
+        private static void FireWithoutHide(Action callback)
+        {
+            try { callback?.Invoke(); }
+            catch (Exception ex) { UnityEngine.Debug.LogError($"[title] callback threw: {ex}"); }
+        }
+
+        private void Update()
+        {
+            if (_overlayGo == null || !_overlayGo.activeSelf) return;
+            if (!_highlightHowToPlay || _howGlow == null) return;
+            // ~0.6Hz pulse between 20% and 60% alpha — visible but
+            // restrained, matches the kit's "gentle nudge" call.
+            _highlightPhase += Time.unscaledDeltaTime;
+            float t = (Mathf.Sin(_highlightPhase * 3.8f) + 1f) * 0.5f;
+            float alpha = Mathf.Lerp(0.20f, 0.60f, t);
+            _howGlow.effectColor = new Color(
+                LedgeUITokens.Accent.r, LedgeUITokens.Accent.g, LedgeUITokens.Accent.b, alpha);
+        }
+
+        // ── UI construction ───────────────────────────────────────────────
+
+        private void BuildUi()
+        {
+            var canvas = GetComponentInParent<Canvas>();
+            if (canvas == null) return;
+
+            _overlayGo = new GameObject("TitleOverlay", typeof(RectTransform));
+            var overlayRt = (RectTransform)_overlayGo.transform;
+            overlayRt.SetParent(canvas.transform, false);
+            overlayRt.anchorMin = Vector2.zero; overlayRt.anchorMax = Vector2.one;
+            overlayRt.offsetMin = Vector2.zero; overlayRt.offsetMax = Vector2.zero;
+            overlayRt.SetAsLastSibling();
+
+            // Bottom-scrim gradient — transparent top → opaque bottom so the
+            // dream backdrop reads at the top and the title lockup pops at
+            // the bottom.
+            var scrimGo = new GameObject("Scrim", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            var scrimRt = (RectTransform)scrimGo.transform;
+            scrimRt.SetParent(overlayRt, false);
+            scrimRt.anchorMin = Vector2.zero; scrimRt.anchorMax = Vector2.one;
+            scrimRt.offsetMin = Vector2.zero; scrimRt.offsetMax = Vector2.zero;
+            var scrimImg = scrimGo.GetComponent<Image>();
+            scrimImg.sprite = GetVerticalScrimSprite();
+            scrimImg.color = Color.white;
+            scrimImg.raycastTarget = true;
+            scrimImg.type = Image.Type.Simple;
+            scrimImg.preserveAspect = false;
+
+            // Title lockup — anchored bottom-center, rises 196px to clear
+            // the action row (36 + button height ~52 + tagline + margin).
+            var lockupGo = new GameObject("Lockup", typeof(RectTransform));
+            var lockupRt = (RectTransform)lockupGo.transform;
+            lockupRt.SetParent(overlayRt, false);
+            lockupRt.anchorMin = new Vector2(0.5f, 0f);
+            lockupRt.anchorMax = new Vector2(0.5f, 0f);
+            lockupRt.pivot = new Vector2(0.5f, 0f);
+            lockupRt.anchoredPosition = new Vector2(0f, 196f);
+            lockupRt.sizeDelta = new Vector2(900f, 180f);
+
+            var vl = lockupGo.AddComponent<VerticalLayoutGroup>();
+            vl.spacing = 18f;
+            vl.childAlignment = TextAnchor.MiddleCenter;
+            vl.childControlWidth = true;
+            vl.childControlHeight = false;
+            vl.childForceExpandWidth = true;
+            vl.childForceExpandHeight = false;
+
+            var titleText = MakeText(lockupRt, "Title", LedgeUITokens.DisplayFont, 120f, LedgeUITokens.Ink, "Ledge");
+            titleText.fontStyle = FontStyles.Italic;
+            titleText.alignment = TextAlignmentOptions.Center;
+            titleText.characterSpacing = -3f; // ~-0.03em at this size
+            // Cool-accent glow per kit's textShadow rgba(143,180,255,0.25).
+            // Outline at small offset is the cheapest reasonable facsimile;
+            // real text-shadow blur would need a custom shader.
+            var glow = titleText.gameObject.AddComponent<Outline>();
+            glow.effectColor = new Color(LedgeUITokens.AccentCool.r, LedgeUITokens.AccentCool.g, LedgeUITokens.AccentCool.b, 0.25f);
+            glow.effectDistance = new Vector2(2f, -2f);
+            glow.useGraphicAlpha = true;
+            AddLayoutHeight(titleText.gameObject, 132f);
+
+            var taglineText = MakeText(lockupRt, "Tagline", LedgeUITokens.MonoFont, 11f, LedgeUITokens.InkFaint,
+                "A WHEEL OF TWELVE SPIRITS");
+            taglineText.fontStyle = FontStyles.UpperCase;
+            taglineText.characterSpacing = 42f; // ~0.42em
+            taglineText.alignment = TextAlignmentOptions.Center;
+            AddLayoutHeight(taglineText.gameObject, 14f);
+
+            // Action row — anchored bottom-center.
+            var actionsGo = new GameObject("Actions", typeof(RectTransform));
+            var actionsRt = (RectTransform)actionsGo.transform;
+            actionsRt.SetParent(overlayRt, false);
+            actionsRt.anchorMin = new Vector2(0.5f, 0f);
+            actionsRt.anchorMax = new Vector2(0.5f, 0f);
+            actionsRt.pivot = new Vector2(0.5f, 0f);
+            actionsRt.anchoredPosition = new Vector2(0f, 36f);
+            actionsRt.sizeDelta = new Vector2(800f, 52f);
+
+            var hl = actionsGo.AddComponent<HorizontalLayoutGroup>();
+            hl.spacing = 14f;
+            hl.childAlignment = TextAnchor.MiddleCenter;
+            hl.childControlWidth = false;
+            hl.childControlHeight = true;
+            hl.childForceExpandWidth = false;
+            hl.childForceExpandHeight = true;
+
+            // Play / Practice hide the title (transition to lobby); How-to-
+            // play / Settings open a modal on top and leave the title
+            // visible behind. Different semantics → different click paths.
+            var playBtn = LedgeButton.Build(actionsRt, "Play", LedgeButton.Variant.Primary, LedgeButton.Size.Lg,
+                () => FireAndHide(_onPlay));
+            var playLe = playBtn.gameObject.AddComponent<LayoutElement>();
+            playLe.minWidth = 160f; playLe.preferredWidth = 160f;
+
+            var practiceBtn = LedgeButton.Build(actionsRt, "Practice", LedgeButton.Variant.Ghost, LedgeButton.Size.Lg,
+                () => FireAndHide(_onPractice));
+            var practiceLe = practiceBtn.gameObject.AddComponent<LayoutElement>();
+            practiceLe.preferredWidth = 140f; practiceLe.minWidth = 120f;
+
+            _howBtn = LedgeButton.Build(actionsRt, "How to play", LedgeButton.Variant.Ghost, LedgeButton.Size.Lg,
+                () =>
+                {
+                    // First-launch nudge stops the moment the user actually
+                    // clicks the highlighted button — don't keep pulsing if
+                    // they're already engaging with the tutorial.
+                    _highlightHowToPlay = false;
+                    if (_howGlow != null) _howGlow.effectColor = new Color(0f, 0f, 0f, 0f);
+                    FireWithoutHide(_onHowToPlay);
+                });
+            var howLe = _howBtn.gameObject.AddComponent<LayoutElement>();
+            howLe.preferredWidth = 160f; howLe.minWidth = 140f;
+
+            // Dedicated halo Outline for F6 pulse. LedgeButton already adds
+            // its own variant outline; this is a second Outline at a wider
+            // effectDistance whose alpha we animate. Starts transparent so
+            // non-highlighted Shows render normally.
+            _howGlow = _howBtn.gameObject.AddComponent<Outline>();
+            _howGlow.effectDistance = new Vector2(3f, -3f);
+            _howGlow.effectColor = new Color(0f, 0f, 0f, 0f);
+            _howGlow.useGraphicAlpha = true;
+
+            var settingsBtn = LedgeButton.Build(actionsRt, "Settings", LedgeButton.Variant.Ghost, LedgeButton.Size.Lg,
+                () => FireWithoutHide(_onSettings));
+            var settingsLe = settingsBtn.gameObject.AddComponent<LayoutElement>();
+            settingsLe.preferredWidth = 130f; settingsLe.minWidth = 120f;
+
+            // Version footer — bottom-right.
+            var verGo = MakeText(overlayRt, "Version", LedgeUITokens.MonoFont, 9.5f, LedgeUITokens.InkMute,
+                versionString ?? "").rectTransform;
+            var verTmp = verGo.GetComponent<TMP_Text>();
+            verTmp.fontStyle = FontStyles.UpperCase;
+            verTmp.characterSpacing = 16f;
+            verTmp.alignment = TextAlignmentOptions.BottomRight;
+            verGo.anchorMin = new Vector2(1f, 0f);
+            verGo.anchorMax = new Vector2(1f, 0f);
+            verGo.pivot = new Vector2(1f, 0f);
+            verGo.anchoredPosition = new Vector2(-20f, 14f);
+            verGo.sizeDelta = new Vector2(220f, 14f);
+        }
+
+        // ── Build helpers ─────────────────────────────────────────────────
+
+        private static TMP_Text MakeText(Transform parent, string name, TMP_FontAsset font,
+                                         float size, Color color, string text)
+        {
+            var go = new GameObject(name, typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var t = go.AddComponent<TextMeshProUGUI>();
+            t.font = font;
+            t.fontSize = size;
+            t.color = color;
+            t.text = text;
+            t.raycastTarget = false;
+            return t;
+        }
+
+        private static void AddLayoutHeight(GameObject go, float height)
+        {
+            var le = go.GetComponent<LayoutElement>() ?? go.AddComponent<LayoutElement>();
+            le.minHeight = height;
+            le.preferredHeight = height;
+        }
+
+        // Vertical scrim gradient: transparent → fade → opaque from top to
+        // bottom. Three stops per the kit:
+        //   0-40%   transparent
+        //   40-78%  0 → 0.85 alpha
+        //   78-100% 0.85 → 0.97 alpha
+        // 1×256 sprite stretched vertically to canvas height. The y axis in
+        // Unity sprite space runs bottom-up, so the kit's "180deg" gradient
+        // (which goes top→bottom) maps to bottom-up alpha 0.97 → 0.85 → 0
+        // → 0 here.
+        private static Sprite GetVerticalScrimSprite()
+        {
+            if (_verticalScrimSprite != null) return _verticalScrimSprite;
+            const int H = 256;
+            var tex = new Texture2D(1, H, TextureFormat.RGBA32, false)
+            {
+                filterMode = FilterMode.Bilinear,
+                wrapMode = TextureWrapMode.Clamp,
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            var px = new Color32[H];
+            const byte R = 10, G = 13, B = 27;
+            for (int y = 0; y < H; y++)
+            {
+                // t=0 bottom, t=1 top in sprite-space → invert for kit's top-down.
+                float tTop = 1f - (y / (float)(H - 1));
+                float alpha;
+                if (tTop < 0.40f) alpha = 0f;
+                else if (tTop < 0.78f) alpha = Mathf.Lerp(0f, 0.85f, (tTop - 0.40f) / 0.38f);
+                else alpha = Mathf.Lerp(0.85f, 0.97f, (tTop - 0.78f) / 0.22f);
+                px[y] = new Color32(R, G, B, (byte)(alpha * 255f));
+            }
+            tex.SetPixels32(px);
+            tex.Apply(false, false);
+            _verticalScrimSprite = Sprite.Create(tex, new Rect(0, 0, 1, H), new Vector2(0.5f, 0.5f), 100f, 0, SpriteMeshType.FullRect);
+            _verticalScrimSprite.hideFlags = HideFlags.HideAndDontSave;
+            return _verticalScrimSprite;
+        }
+    }
+}

--- a/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeTitlePanel.cs.meta
+++ b/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeTitlePanel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3965ac527dba6ba4fad3ac8fc3cdde8b

--- a/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeTutorialPanel.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeTutorialPanel.cs
@@ -1,0 +1,341 @@
+using System;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Magi.LedgeBoardGame.UI
+{
+    /// "How to play" / tutorial screen. Built from
+    /// `kit/ledge-board-game/project/ui/frame-tutorial.jsx` → TutorialFrame:
+    /// a 2-column split with a highlighted board diagram on the left and a
+    /// stepped explanation on the right (Fraunces italic "Four ideas." +
+    /// four numbered steps + Start practice / Skip actions).
+    ///
+    /// The board diagram is omitted from this port for the same reason as
+    /// the title hero: no isolated BoardFrame surface yet outside a live
+    /// BoardPresenter. The right-side copy carries the load.
+    ///
+    /// Copy is verbatim from the kit (flagged in handoff v4 §3.12 as
+    /// placeholder — confirm against rules in a follow-up pass).
+    public class LedgeTutorialPanel : MonoBehaviour
+    {
+        private GameObject _overlayGo;
+        private Action _onStartPractice;
+        private Action _onSkip;
+
+        private static readonly (int n, string title, string body)[] Steps =
+        {
+            (1, "The wheel", "Each board is a wheel of twelve spirit colors, four rings deep, with twelve outer Ledges."),
+            (2, "Place & move", "Spend energy to place Light or Dark counters, then move stacks inward and outward along the rings."),
+            (3, "Cross the Ledge", "From an outer Ledge you can cross onto an opponent's board — affecting their spaces only while you pass through."),
+            (4, "Claim a Core", "Reach the center to claim a Core. Hold the most when the wheel runs out of moves."),
+        };
+
+        private void Awake() => EnsureBuilt();
+
+        public void EnsureBuilt()
+        {
+            if (_overlayGo != null) return;
+            BuildUi();
+            HideInternal();
+        }
+
+        // ── Public API ─────────────────────────────────────────────────────
+
+        public void Show(Action onStartPractice, Action onSkip)
+        {
+            EnsureBuilt();
+            _onStartPractice = onStartPractice;
+            _onSkip = onSkip;
+            _overlayGo.SetActive(true);
+            _overlayGo.transform.SetAsLastSibling();
+        }
+
+        public void Hide() => HideInternal();
+
+        public bool IsShowing => _overlayGo != null && _overlayGo.activeSelf;
+
+        [ContextMenu("Show Tutorial (Test)")]
+        private void ShowTestPreview()
+        {
+            Show(
+                onStartPractice: () => UnityEngine.Debug.Log("[tutorial] Start practice (test)"),
+                onSkip: () => UnityEngine.Debug.Log("[tutorial] Skip (test)"));
+        }
+
+        // ── Internals ─────────────────────────────────────────────────────
+
+        private void HideInternal()
+        {
+            if (_overlayGo != null) _overlayGo.SetActive(false);
+        }
+
+        private void FireAndHide(Action callback)
+        {
+            HideInternal();
+            try { callback?.Invoke(); }
+            catch (Exception ex) { UnityEngine.Debug.LogError($"[tutorial] callback threw: {ex}"); }
+        }
+
+        // ── UI construction ───────────────────────────────────────────────
+
+        private void BuildUi()
+        {
+            var canvas = GetComponentInParent<Canvas>();
+            if (canvas == null) return;
+
+            _overlayGo = new GameObject("TutorialOverlay", typeof(RectTransform));
+            var overlayRt = (RectTransform)_overlayGo.transform;
+            overlayRt.SetParent(canvas.transform, false);
+            overlayRt.anchorMin = Vector2.zero; overlayRt.anchorMax = Vector2.one;
+            overlayRt.offsetMin = Vector2.zero; overlayRt.offsetMax = Vector2.zero;
+            overlayRt.SetAsLastSibling();
+
+            // Solid canvas backdrop — tutorial is a full takeover.
+            var bgGo = new GameObject("Backdrop", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            var bgRt = (RectTransform)bgGo.transform;
+            bgRt.SetParent(overlayRt, false);
+            bgRt.anchorMin = Vector2.zero; bgRt.anchorMax = Vector2.one;
+            bgRt.offsetMin = Vector2.zero; bgRt.offsetMax = Vector2.zero;
+            var bgImg = bgGo.GetComponent<Image>();
+            bgImg.color = LedgeUITokens.Canvas;
+            bgImg.raycastTarget = true;
+
+            // Copy column carrying all the type. The kit's left column has a
+            // highlighted board diagram; we omit that (no isolated BoardFrame
+            // surface yet). With the diagram gone, anchoring to the right half
+            // left the composition visibly lopsided, so the column is a fixed-
+            // width block centred on screen instead — a conservative nudge that
+            // keeps the kit's line length while balancing the layout.
+            var rightGo = new GameObject("CopyCol", typeof(RectTransform));
+            var rightRt = (RectTransform)rightGo.transform;
+            rightRt.SetParent(overlayRt, false);
+            rightRt.anchorMin = new Vector2(0.5f, 0.5f);
+            rightRt.anchorMax = new Vector2(0.5f, 0.5f);
+            rightRt.pivot = new Vector2(0.5f, 0.5f);
+            rightRt.sizeDelta = new Vector2(980f, 680f);
+            rightRt.anchoredPosition = Vector2.zero;
+
+            var vl = rightGo.AddComponent<VerticalLayoutGroup>();
+            vl.spacing = 0f;
+            vl.padding = new RectOffset(56, 56, 0, 0);
+            vl.childAlignment = TextAnchor.MiddleLeft;
+            vl.childControlWidth = true;
+            // childControlHeight=true so nested sub-groups (Steps, Actions) and
+            // LayoutElement-declared heights are both measured AND sized by this
+            // group. With it false the group ignored the Steps sub-group's
+            // preferred height and stacked the Actions row on top of the steps.
+            vl.childControlHeight = true;
+            vl.childForceExpandWidth = true;
+            vl.childForceExpandHeight = false;
+
+            // Section label
+            var section = MakeText(rightRt, "SectionLabel", LedgeUITokens.MonoFont,
+                LedgeUITokens.SectionLabelSize, LedgeUITokens.InkDim, "HOW TO PLAY");
+            section.fontStyle = FontStyles.UpperCase;
+            section.characterSpacing = 22f;
+            section.alignment = TextAlignmentOptions.MidlineLeft;
+            AddLayoutHeight(section.gameObject, 18f);
+
+            AddVerticalSpacer(rightRt, 14f);
+
+            // Display italic "Four ideas."
+            var headline = MakeText(rightRt, "Headline", LedgeUITokens.DisplayFont, 44f, LedgeUITokens.Ink, "Four ideas.");
+            headline.fontStyle = FontStyles.Italic;
+            headline.alignment = TextAlignmentOptions.MidlineLeft;
+            AddLayoutHeight(headline.gameObject, 50f);
+
+            AddVerticalSpacer(rightRt, 36f);
+
+            // Steps container
+            var stepsGo = new GameObject("Steps", typeof(RectTransform));
+            var stepsRt = (RectTransform)stepsGo.transform;
+            stepsRt.SetParent(rightRt, false);
+            var stepsVl = stepsGo.AddComponent<VerticalLayoutGroup>();
+            stepsVl.spacing = 22f;
+            stepsVl.childAlignment = TextAnchor.UpperLeft;
+            stepsVl.childControlWidth = true;
+            // Control height so each row's declared LayoutElement height sizes
+            // the row and rolls up into this group's preferred height (which the
+            // parent CopyCol now reads to reserve the steps' full footprint).
+            stepsVl.childControlHeight = true;
+            stepsVl.childForceExpandWidth = true;
+            stepsVl.childForceExpandHeight = false;
+
+            foreach (var step in Steps)
+            {
+                BuildStepRow(stepsRt, step.n, step.title, step.body);
+            }
+
+            AddVerticalSpacer(rightRt, 40f);
+
+            // Action row
+            var actionsGo = new GameObject("Actions", typeof(RectTransform));
+            var actionsRt = (RectTransform)actionsGo.transform;
+            actionsRt.SetParent(rightRt, false);
+            var hl = actionsGo.AddComponent<HorizontalLayoutGroup>();
+            hl.spacing = 12f;
+            hl.childAlignment = TextAnchor.MiddleLeft;
+            // Control both axes from the buttons' LayoutElements: width so the
+            // preferred widths below actually apply (with childControlWidth off
+            // the group ignored them and the buttons collapsed to 100px), and
+            // height WITHOUT force-expand so the buttons keep their ~48px height
+            // instead of stretching. force-expand-height also made this row
+            // report flexibleHeight to CopyCol, which dumped its vertical slack
+            // here and ballooned the buttons; keeping it false pins the row.
+            hl.childControlWidth = true;
+            hl.childControlHeight = true;
+            hl.childForceExpandWidth = false;
+            hl.childForceExpandHeight = false;
+            AddLayoutHeight(actionsGo, 52f);
+
+            var startBtn = LedgeButton.Build(actionsRt, "Start practice", LedgeButton.Variant.Primary, LedgeButton.Size.Lg,
+                () => FireAndHide(_onStartPractice));
+            var startLe = startBtn.gameObject.AddComponent<LayoutElement>();
+            startLe.preferredWidth = 210f; startLe.minWidth = 190f;
+            startLe.preferredHeight = 48f; startLe.minHeight = 44f;
+
+            var skipBtn = LedgeButton.Build(actionsRt, "Skip", LedgeButton.Variant.Ghost, LedgeButton.Size.Lg,
+                () => FireAndHide(_onSkip));
+            var skipLe = skipBtn.gameObject.AddComponent<LayoutElement>();
+            skipLe.preferredWidth = 110f; skipLe.minWidth = 90f;
+            skipLe.preferredHeight = 48f; skipLe.minHeight = 44f;
+        }
+
+        private static void BuildStepRow(Transform parent, int n, string title, string body)
+        {
+            var rowGo = new GameObject($"Step_{n}", typeof(RectTransform));
+            var rowRt = (RectTransform)rowGo.transform;
+            rowRt.SetParent(parent, false);
+            var hl = rowGo.AddComponent<HorizontalLayoutGroup>();
+            hl.spacing = 18f;
+            hl.childAlignment = TextAnchor.UpperLeft;
+            hl.childControlWidth = true;
+            // Control height so the number badge and the text column are both
+            // measured/sized from their declared heights rather than a stale
+            // rect. Row height bumped to 76 to give two-line bodies headroom.
+            hl.childControlHeight = true;
+            hl.childForceExpandWidth = false;
+            hl.childForceExpandHeight = false;
+            AddLayoutHeight(rowGo, 76f);
+
+            // Numbered circle: 34×34 rounded square with thin border + italic
+            // accent numeral. Unity UI can't draw a circle without a sprite,
+            // so we render the disc and rely on padding to centre the digit.
+            var circleGo = new GameObject("Number",
+                typeof(RectTransform), typeof(CanvasRenderer), typeof(Image),
+                typeof(Outline), typeof(LayoutElement));
+            circleGo.transform.SetParent(rowRt, false);
+            var circleImg = circleGo.GetComponent<Image>();
+            circleImg.sprite = GetCircleSprite();
+            circleImg.color = new Color(0f, 0f, 0f, 0f);
+            circleImg.raycastTarget = false;
+            var circleOutline = circleGo.GetComponent<Outline>();
+            circleOutline.effectColor = LedgeUITokens.PanelEdge2;
+            circleOutline.effectDistance = new Vector2(LedgeUITokens.HairlineWidth, -LedgeUITokens.HairlineWidth);
+            var circleLe = circleGo.GetComponent<LayoutElement>();
+            circleLe.minWidth = 34f; circleLe.preferredWidth = 34f;
+            circleLe.minHeight = 34f; circleLe.preferredHeight = 34f;
+
+            var nText = MakeText(circleGo.transform, "N", LedgeUITokens.DisplayFont, 16f, LedgeUITokens.Accent, n.ToString());
+            nText.fontStyle = FontStyles.Italic;
+            nText.alignment = TextAlignmentOptions.Center;
+            var nRt = nText.rectTransform;
+            nRt.anchorMin = Vector2.zero; nRt.anchorMax = Vector2.one;
+            nRt.offsetMin = Vector2.zero; nRt.offsetMax = Vector2.zero;
+
+            // Title + body stacked.
+            var textColGo = new GameObject("TextCol", typeof(RectTransform));
+            var textColRt = (RectTransform)textColGo.transform;
+            textColRt.SetParent(rowRt, false);
+            var colVl = textColGo.AddComponent<VerticalLayoutGroup>();
+            colVl.spacing = 4f;
+            colVl.childAlignment = TextAnchor.UpperLeft;
+            colVl.childControlWidth = true;
+            // Control height so the title + body declared heights size the
+            // labels and sum into this column's preferred height (read by the
+            // row's HorizontalLayoutGroup to size the whole step).
+            colVl.childControlHeight = true;
+            colVl.childForceExpandWidth = true;
+            colVl.childForceExpandHeight = false;
+            var textColLe = textColGo.AddComponent<LayoutElement>();
+            textColLe.flexibleWidth = 1f;
+            textColLe.minWidth = 200f;
+
+            var titleText = MakeText(textColRt, "Title", LedgeUITokens.UIFont, 16f, LedgeUITokens.Ink, title);
+            titleText.fontStyle = FontStyles.Bold;
+            titleText.alignment = TextAlignmentOptions.TopLeft;
+            AddLayoutHeight(titleText.gameObject, 20f);
+
+            var bodyText = MakeText(textColRt, "Body", LedgeUITokens.UIFont, 13.5f, LedgeUITokens.InkFaint, body);
+            bodyText.alignment = TextAlignmentOptions.TopLeft;
+            bodyText.textWrappingMode = TextWrappingModes.Normal;
+            // 48px holds up to three wrapped lines of body copy at 13.5pt; the
+            // narrower centred column wraps the longer steps to two lines.
+            AddLayoutHeight(bodyText.gameObject, 48f);
+        }
+
+        // ── Build helpers ─────────────────────────────────────────────────
+
+        private static TMP_Text MakeText(Transform parent, string name, TMP_FontAsset font,
+                                         float size, Color color, string text)
+        {
+            var go = new GameObject(name, typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var t = go.AddComponent<TextMeshProUGUI>();
+            t.font = font;
+            t.fontSize = size;
+            t.color = color;
+            t.text = text;
+            t.raycastTarget = false;
+            return t;
+        }
+
+        private static void AddLayoutHeight(GameObject go, float height)
+        {
+            var le = go.GetComponent<LayoutElement>() ?? go.AddComponent<LayoutElement>();
+            le.minHeight = height;
+            le.preferredHeight = height;
+        }
+
+        private static void AddVerticalSpacer(Transform parent, float height)
+        {
+            var go = new GameObject("Spacer", typeof(RectTransform), typeof(LayoutElement));
+            go.transform.SetParent(parent, false);
+            var le = go.GetComponent<LayoutElement>();
+            le.minHeight = height;
+            le.preferredHeight = height;
+        }
+
+        // Cached AA circle sprite for the numbered step badges. Same
+        // technique as elsewhere in the kit chrome.
+        private static Sprite _circleSprite;
+        private static Sprite GetCircleSprite()
+        {
+            if (_circleSprite != null) return _circleSprite;
+            const int N = 64;
+            var tex = new Texture2D(N, N, TextureFormat.RGBA32, false)
+            {
+                filterMode = FilterMode.Bilinear,
+                wrapMode = TextureWrapMode.Clamp,
+                hideFlags = HideFlags.HideAndDontSave,
+            };
+            var px = new Color32[N * N];
+            float c = (N - 1) * 0.5f;
+            float rOuter = c;
+            for (int y = 0; y < N; y++)
+                for (int x = 0; x < N; x++)
+                {
+                    float dx = x - c, dy = y - c;
+                    float d = Mathf.Sqrt(dx * dx + dy * dy);
+                    float a = Mathf.Clamp01(rOuter - d);
+                    px[y * N + x] = new Color32(255, 255, 255, (byte)(a * 255f));
+                }
+            tex.SetPixels32(px);
+            tex.Apply(false, false);
+            _circleSprite = Sprite.Create(tex, new Rect(0, 0, N, N), new Vector2(0.5f, 0.5f), 100f, 0, SpriteMeshType.FullRect);
+            _circleSprite.hideFlags = HideFlags.HideAndDontSave;
+            return _circleSprite;
+        }
+    }
+}

--- a/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeTutorialPanel.cs.meta
+++ b/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeTutorialPanel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7bb00e59664301245aaace1906f8828d


### PR DESCRIPTION
## Summary

Landscape + portrait UI polish for the Ledge lobby/gameplay overlays:

- Add title, tutorial, setup, and settings overlays with Account → Setup routing.
- Repair Settings rows with deterministic anchored bands and add a true phone/portrait breakpoint.
- Tune control-handoff visuals: visitor pill placement, entry-tile overlay/halo, and counter layering.
- Include Unity `.meta` files for the new UI scripts so the branch is self-contained in a clean checkout.

## Test plan

- Final integrated smoke via Unity MCP (`cp021`): **0 errors / 0 warnings**.
- Landscape `2560×1440`:
  - title / landing,
  - Settings → Account → Setup sub-route,
  - Setup Back → Settings single-overlay return,
  - Tutorial,
  - local Practice board,
  - control-handoff visitor state.
- Portrait `720×1280`:
  - Settings single-column layout, all cards/rows/controls visible, no horizontal clipping.
- Regression captures:
  - Settings landscape at `2560×1440`,
  - Settings smaller landscape at `1280×720`,
  - Settings portrait at `720×1280`.
- Reviewer loop:
  - Gemini and Codex approved the Settings row layout and portrait breakpoint with notes/no blockers.
  - Claude accepted cp020/cp022/cp024 relay decisions.

## Notes

- Local worktree still has unrelated dirty/untracked files, but they are **not included** in this branch/PR.
- Excluded from this PR: package/project settings drift, TextMesh Pro fallback atlas touch, broader board/HUD/endgame/takeback UI work, and kit-import reference directories.
- Deferred nonblocking polish: Tutorial portrait copy-width clamp, Setup portrait side margin, Practice portrait top-right HUD clipping, and optional Settings height-only resize hardening.
