### PR TITLE
fix(ledge): contain practice board view controls

### DIFF
--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardViewHud.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardViewHud.cs
@@ -100,7 +100,12 @@ namespace Magi.LedgeBoardGame.Board
             var hl = _comparisonGroup.gameObject.AddComponent<HorizontalLayoutGroup>();
             hl.spacing = 8f;
             hl.childAlignment = TextAnchor.MiddleCenter;
-            hl.childControlWidth = false;
+            // Control width so the prev/next buttons honour their 44px
+            // LayoutElement and the label takes the flexible remainder. With it
+            // false the buttons rendered at their default width and the row
+            // (< Board N >) overflowed the 280px panel — clipping off the right
+            // screen edge, most visibly in narrow portrait.
+            hl.childControlWidth = true;
             hl.childControlHeight = true;
             hl.childForceExpandWidth = false;
             hl.childForceExpandHeight = true;


### PR DESCRIPTION
## Summary

- Contains the Practice/Comparison Board View controls in portrait by allowing the comparison row layout group to control child widths.
- Keeps the `<`, `Board N`, and `>` row inside the top-right `BoardViewHud` panel instead of clipping the right cycler off-screen at 720×1280.
- Cherry-picks only the reviewed `BoardViewHud.cs` fix from the WIP branch onto a clean `origin/main` base.

## Verification

- Unity MCP: 720×1280 practice portrait before/after screenshots (`cp036/01` → `cp036/03`) confirmed the right cycler moved from clipped/off-screen to fully inside the panel.
- Unity MCP: 2560×1440 landscape regression screenshot (`cp036/04`) showed no BoardViewHud regression.
- Runtime rect metrics after fix:
  - portrait: `<` [528,557], `Board 1` [563,653], `>` [659,688], panel [515,701]
  - landscape: BoardViewHud [2149,2523], ComparisonControls [2176,2496]
- Unity cleanup from cp036: console 0 errors / 0 warnings; `isPlaying=false`; `isCompiling=false`; PlayerPrefs/render resolution restored.
- `git diff --check -- LedgeBoardGame/Assets/_Project/Scripts/Board/BoardViewHud.cs` passed.
- Source/design review:
  - Gemini: approve, no blockers
  - Codex: approve_with_notes, no blockers
  - Claude Design: approve, no blockers

## Carry-forward / not in this PR

- Portrait `BOARD VIEW` eyebrow legibility/tightness.
- Existing instruction / `SEATS` overlap.
- The larger WIP gameplay/HUD batch on `wip/ledge-current-hud-state-cp035`.