### PR TITLE
feat(ledge): add comparison seats strip

### DIFF
--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardThumbStrip.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardThumbStrip.cs
@@ -1,0 +1,382 @@
+using System.Collections.Generic;
+using Magi.LedgeBoardGame.Models;
+using Magi.LedgeBoardGame.UI;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Magi.LedgeBoardGame.Board
+{
+    /// Bottom-center thumbnail strip for 6-8 seat sessions. Each `SeatThumb`
+    /// shows the seat's skin chip + display name; clicking a thumb pins
+    /// that seat into Comparison's right slot without cycling through the
+    /// others. Mirrors `kit/ledge-board-game/project/ui/frame-hud-np.jsx` →
+    /// thumbnail strip block.
+    ///
+    /// Visibility rules:
+    ///   - hidden when seat count < 6 (the cycler alone is sufficient)
+    ///   - hidden when not in Comparison mode (no "right slot" to drive)
+    ///   - hidden when no game state attached yet (boot)
+    ///
+    /// Procedurally constructed; no prefab dependency.
+    public class BoardThumbStrip : MonoBehaviour
+    {
+        [Tooltip("Minimum seat count at which the strip appears. The cycler in BoardViewHud already covers ≤5 seats, so the strip exists to short-circuit a long cycle.")]
+        [SerializeField] private int minSeatCount = 6;
+
+        private MultiBoardLayout _layout;
+        private GameState _state;
+
+        private RectTransform _rootRect;
+        private RectTransform _canvasRect;
+        private RectTransform _row;
+        private TMP_Text _seatsLabel;
+
+        // Deterministic layout metrics. The strip does NOT rely on a
+        // ContentSizeFitter (in this procedural canvas the fitter collapsed
+        // the root to 0×0); instead the width is computed from seat count
+        // and clamped to the canvas, and the row's HorizontalLayoutGroup
+        // controls child widths from these values.
+        private const float StripHeight = 64f;
+        private const float RowSpacing = 8f;
+        private const float LabelWidth = 56f;
+        private const float ThumbPreferredWidth = 132f;
+        private const float ThumbMinWidth = 96f;
+        // Absolute floor used only when the canvas is too narrow to fit even
+        // ThumbMinWidth thumbs (e.g. 8 seats on a 720px portrait canvas). At
+        // this point names ellipsize; the strip still never exceeds the canvas.
+        private const float CompactThumbMinWidth = 60f;
+        private const float GlassPadX = 12f;    // matches LedgeGlassPanel padding.x below
+        private const float SafeEdgeInset = 24f; // keep clear of canvas edges
+
+        // boardId → thumb hooks so Refresh can re-tint without rebuilding.
+        private struct Thumb
+        {
+            public GameObject Root;
+            public Image Background;
+            public Outline Outline;
+            public TMP_Text Name;
+            public TMP_Text Caption;
+        }
+        private readonly Dictionary<int, Thumb> _thumbs = new Dictionary<int, Thumb>();
+
+        public void Initialize(MultiBoardLayout layout, GameState state)
+        {
+            _layout = layout;
+            _state = state;
+            BuildUi();
+            if (_layout != null) _layout.LayoutChanged += Refresh;
+            Refresh();
+        }
+
+        public void UpdateGameState(GameState state)
+        {
+            _state = state;
+            Refresh();
+        }
+
+        private void OnDestroy()
+        {
+            if (_layout != null) _layout.LayoutChanged -= Refresh;
+        }
+
+        public void Refresh()
+        {
+            if (_rootRect == null) return;
+
+            bool show = ShouldShow();
+            _rootRect.gameObject.SetActive(show);
+            if (!show) return;
+
+            // Cheap (≤8 seats) — rebuild on every refresh to absorb roster
+            // mutations (rename, JIP, late-join) without tracking deltas.
+            RebuildThumbs();
+        }
+
+        private bool ShouldShow()
+        {
+            if (_layout == null || _state == null) return false;
+            if (_layout.Mode != MultiBoardLayout.ViewMode.Comparison) return false;
+            if (_state.Boards == null || _state.Boards.Count < minSeatCount) return false;
+            return true;
+        }
+
+        // ── UI construction ────────────────────────────────────────────────
+
+        private void BuildUi()
+        {
+            var canvas = GetComponentInParent<Canvas>();
+            if (canvas == null) return;
+            _canvasRect = canvas.transform as RectTransform;
+
+            var root = new GameObject("BoardThumbStrip", typeof(RectTransform));
+            _rootRect = (RectTransform)root.transform;
+            _rootRect.SetParent(canvas.transform, false);
+            _rootRect.anchorMin = new Vector2(0.5f, 0f);
+            _rootRect.anchorMax = new Vector2(0.5f, 0f);
+            _rootRect.pivot = new Vector2(0.5f, 0f);
+            // Kit specifies bottom-center at 26px above the canvas edge, but
+            // Unity's BL StatusLog (420×180) and BR ActionBar (360×64) both
+            // anchor to the bottom; a center-anchored strip at the same Y
+            // would collide. Lift it above the taller chrome (StatusLog) so
+            // the kit's bottom-center read is preserved without overlap.
+            // 28 (inset) + 180 (StatusLog) + 14 (panel gap) = 222.
+            _rootRect.anchoredPosition = new Vector2(0f, 222f);
+            // Explicit initial size; RebuildThumbs() recomputes width from the
+            // live seat count and clamps it to the canvas each Refresh.
+            _rootRect.sizeDelta = new Vector2(600f, StripHeight);
+            _rootRect.SetAsLastSibling();
+
+            var glass = LedgeGlassPanel.Build(_rootRect, "Glass", padding: new Vector2(GlassPadX, 10f));
+            var gRt = glass.GetComponent<RectTransform>();
+            gRt.anchorMin = Vector2.zero;
+            gRt.anchorMax = Vector2.one;
+            gRt.offsetMin = Vector2.zero;
+            gRt.offsetMax = Vector2.zero;
+
+            // Horizontal row: "SEATS N" label + N seat thumbs.
+            var rowGo = new GameObject("Row", typeof(RectTransform));
+            _row = (RectTransform)rowGo.transform;
+            _row.SetParent(glass.Content, false);
+            _row.anchorMin = Vector2.zero;
+            _row.anchorMax = Vector2.one;
+            _row.offsetMin = Vector2.zero;
+            _row.offsetMax = Vector2.zero;
+            var hl = rowGo.AddComponent<HorizontalLayoutGroup>();
+            hl.spacing = RowSpacing;
+            hl.childAlignment = TextAnchor.MiddleLeft;
+            // Control child widths so each thumb honours its LayoutElement
+            // (preferred/min) and shrinks gracefully when the clamped strip
+            // is narrower than the sum of preferred widths. Relying on the
+            // children's own rects (childControlWidth=false) + a
+            // ContentSizeFitter collapsed the root to 0×0 in this canvas.
+            hl.childControlWidth = true;
+            hl.childControlHeight = true;
+            hl.childForceExpandWidth = false;
+            hl.childForceExpandHeight = false;
+
+            _seatsLabel = MakeText(_row, "SeatsLabel", LedgeUITokens.MonoFont,
+                LedgeUITokens.SectionLabelSize, LedgeUITokens.Ink, "SEATS 0");
+            _seatsLabel.fontStyle = FontStyles.UpperCase;
+            // Lighter tracking + full-strength ink so the strip's own title
+            // stays legible at 8 seats (Claude Design fold-in). Heavy 22f
+            // tracking read as noise at the compact label width.
+            _seatsLabel.characterSpacing = 12f;
+            var labelLe = _seatsLabel.gameObject.AddComponent<LayoutElement>();
+            labelLe.minWidth = LabelWidth;
+            labelLe.preferredWidth = LabelWidth;
+            labelLe.flexibleWidth = 0f;
+        }
+
+        private float RowChrome(int seatCount)
+            => GlassPadX * 2f + LabelWidth + seatCount * RowSpacing; // label + N gaps
+
+        /// Strip width = chrome + N preferred thumbs, but NEVER wider than the
+        /// canvas minus safe insets. Staying inside the canvas takes priority
+        /// over preserving full thumb width — at 8 seats on a 720px portrait
+        /// canvas this returns the (narrower) canvas width, and the thumbs
+        /// compact via ComputeThumbWidth. Absolute lower bound guards only the
+        /// pathological near-zero-canvas case and is itself capped to maxWidth.
+        private float ComputeStripWidth(int seatCount)
+        {
+            float preferred = RowChrome(seatCount) + seatCount * ThumbPreferredWidth;
+            if (_canvasRect == null) return preferred;
+            float maxWidth = _canvasRect.rect.width - SafeEdgeInset * 2f;
+            float floor = Mathf.Min(maxWidth, RowChrome(seatCount) + seatCount * CompactThumbMinWidth);
+            return Mathf.Clamp(preferred, floor, maxWidth);
+        }
+
+        /// Per-thumb width derived from the already-clamped strip width so the
+        /// row (childControlWidth=true) lays thumbs out without pushing the root
+        /// past the canvas. Clamped to [CompactThumbMinWidth, ThumbPreferredWidth].
+        private float ComputeThumbWidth(float stripWidth, int seatCount)
+        {
+            if (seatCount <= 0) return ThumbPreferredWidth;
+            float available = stripWidth - RowChrome(seatCount);
+            float per = available / seatCount;
+            return Mathf.Clamp(per, CompactThumbMinWidth, ThumbPreferredWidth);
+        }
+
+        private void RebuildThumbs()
+        {
+            if (_row == null || _state == null || _layout == null) return;
+
+            int seatCount = _state.Boards?.Count ?? 0;
+            if (_seatsLabel != null) _seatsLabel.text = $"SEATS {seatCount}";
+
+            // Drive the strip width explicitly (no ContentSizeFitter) so the
+            // root has real dimensions; the row HLG then lays out the thumbs.
+            float stripWidth = ComputeStripWidth(seatCount);
+            if (_rootRect != null)
+                _rootRect.sizeDelta = new Vector2(stripWidth, StripHeight);
+            float thumbWidth = ComputeThumbWidth(stripWidth, seatCount);
+
+            // Clear stale thumbs. The label stays — it's the first child.
+            // Walk in reverse so child re-indexing doesn't skip entries.
+            for (int i = _row.childCount - 1; i >= 1; i--)
+            {
+                var child = _row.GetChild(i);
+                if (child != null) DestroyImmediate(child.gameObject);
+            }
+            _thumbs.Clear();
+
+            int currentOpponent = _layout.CurrentOpponentBoardId;
+            int leftId = _layout.ComparisonLeftBoardId;
+            int localId = _layout.LocalBoardId;
+
+            foreach (var b in _state.Boards)
+            {
+                if (b == null) continue;
+                int boardId = b.BoardId;
+
+                bool isActive = boardId == currentOpponent;
+                bool isLeft = boardId == leftId;
+                bool isLocal = boardId == localId;
+
+                string name = ResolveOwnerName(b.PlayerId);
+
+                var thumb = BuildSeatThumb(_row, boardId, name, isLocal, isActive, isLeft, thumbWidth);
+                _thumbs[boardId] = thumb;
+            }
+        }
+
+        private string ResolveOwnerName(int playerId)
+        {
+            if (_state?.Players == null) return $"Player {playerId}";
+            for (int i = 0; i < _state.Players.Count; i++)
+            {
+                var p = _state.Players[i];
+                if (p != null && p.Id == playerId) return p.Name;
+            }
+            return $"Player {playerId}";
+        }
+
+        private Thumb BuildSeatThumb(Transform parent, int boardId, string name,
+                                     bool isLocal, bool isActive, bool isLeft, float thumbWidth)
+        {
+            var go = new GameObject($"Thumb_{boardId}",
+                typeof(RectTransform), typeof(CanvasRenderer), typeof(Image),
+                typeof(Outline), typeof(Button), typeof(HorizontalLayoutGroup),
+                typeof(LayoutElement));
+            go.transform.SetParent(parent, false);
+
+            var bg = go.GetComponent<Image>();
+            var outline = go.GetComponent<Outline>();
+            outline.effectDistance = new Vector2(LedgeUITokens.HairlineWidth, -LedgeUITokens.HairlineWidth);
+            TintSeatThumb(bg, outline, isActive);
+
+            var le = go.GetComponent<LayoutElement>();
+            le.minWidth = thumbWidth;
+            le.preferredWidth = thumbWidth;
+            le.flexibleWidth = 0f;
+            le.minHeight = 38f;
+            le.preferredHeight = 38f;
+
+            var hl = go.GetComponent<HorizontalLayoutGroup>();
+            hl.padding = new RectOffset(8, 12, 7, 7);
+            hl.spacing = 8f;
+            hl.childAlignment = TextAnchor.MiddleLeft;
+            hl.childControlWidth = false;
+            hl.childControlHeight = false;
+            hl.childForceExpandWidth = false;
+            hl.childForceExpandHeight = false;
+
+            // Skin chip placeholder — same flat-dark fill as YouPanel's
+            // chip and the board nameplate's. Will be replaced by the
+            // player's chosen skin once the skin catalog lands.
+            var chipGo = new GameObject("SkinChip",
+                typeof(RectTransform), typeof(CanvasRenderer), typeof(Image),
+                typeof(Outline), typeof(LayoutElement));
+            chipGo.transform.SetParent(go.transform, false);
+            var chipRt = (RectTransform)chipGo.transform;
+            chipRt.sizeDelta = new Vector2(22f, 22f);
+            var chipImg = chipGo.GetComponent<Image>();
+            chipImg.color = new Color(0.10f, 0.12f, 0.22f, 1f);
+            chipImg.raycastTarget = false;
+            var chipOutline = chipGo.GetComponent<Outline>();
+            chipOutline.effectColor = LedgeUITokens.PanelEdge2;
+            chipOutline.effectDistance = new Vector2(LedgeUITokens.HairlineWidth, -LedgeUITokens.HairlineWidth);
+            var chipLe = chipGo.GetComponent<LayoutElement>();
+            chipLe.minWidth = 22f;
+            chipLe.preferredWidth = 22f;
+            chipLe.minHeight = 22f;
+            chipLe.preferredHeight = 22f;
+
+            // Name + optional "YOU" caption stacked vertically.
+            var textCol = new GameObject("TextCol", typeof(RectTransform), typeof(VerticalLayoutGroup));
+            textCol.transform.SetParent(go.transform, false);
+            var col = textCol.GetComponent<VerticalLayoutGroup>();
+            col.spacing = 2f;
+            col.childAlignment = TextAnchor.MiddleLeft;
+            col.childControlWidth = true;
+            col.childControlHeight = true;
+            col.childForceExpandWidth = false;
+            col.childForceExpandHeight = false;
+
+            var nameText = MakeText(textCol.transform, "Name", LedgeUITokens.UIFont, 12f,
+                isActive ? LedgeUITokens.Accent : LedgeUITokens.Ink, name);
+            nameText.fontStyle = FontStyles.Bold;
+            nameText.alignment = TextAlignmentOptions.MidlineLeft;
+
+            TMP_Text caption = null;
+            if (isLocal)
+            {
+                caption = MakeText(textCol.transform, "Caption", LedgeUITokens.MonoFont,
+                    8f, LedgeUITokens.InkDim, "YOU");
+                caption.fontStyle = FontStyles.UpperCase;
+                caption.characterSpacing = 16f;
+                caption.alignment = TextAlignmentOptions.MidlineLeft;
+            }
+
+            // Click → pin this board into the right slot. The local seat
+            // and the current left slot are no-ops (the layout itself
+            // ignores collisions), so we wire the button uniformly and
+            // let SetOpponentBoardId gate.
+            var btn = go.GetComponent<Button>();
+            btn.targetGraphic = bg;
+            int capturedId = boardId;
+            btn.onClick.AddListener(() =>
+            {
+                if (_layout == null) return;
+                _layout.SetOpponentBoardId(capturedId);
+            });
+
+            return new Thumb
+            {
+                Root = go,
+                Background = bg,
+                Outline = outline,
+                Name = nameText,
+                Caption = caption,
+            };
+        }
+
+        private static void TintSeatThumb(Image bg, Outline outline, bool active)
+        {
+            if (active)
+            {
+                bg.color = new Color(LedgeUITokens.Accent.r, LedgeUITokens.Accent.g, LedgeUITokens.Accent.b, 0.10f);
+                outline.effectColor = new Color(LedgeUITokens.Accent.r, LedgeUITokens.Accent.g, LedgeUITokens.Accent.b, 0.45f);
+            }
+            else
+            {
+                bg.color = LedgeUITokens.Panel;
+                outline.effectColor = LedgeUITokens.PanelEdge;
+            }
+        }
+
+        private static TMP_Text MakeText(Transform parent, string name, TMP_FontAsset font,
+                                         float size, Color color, string text)
+        {
+            var go = new GameObject(name, typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var t = go.AddComponent<TextMeshProUGUI>();
+            t.font = font;
+            t.fontSize = size;
+            t.color = color;
+            t.text = text;
+            t.raycastTarget = false;
+            return t;
+        }
+    }
+}

--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardThumbStrip.cs.meta
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardThumbStrip.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1fae04088889fe54ba213c127b005ed6

--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardViewHud.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardViewHud.cs
@@ -21,7 +21,17 @@ namespace Magi.LedgeBoardGame.Board
         {
             _layout = layout;
             BuildUi();
+            // Keep the top-right "Board N" label in sync when the layout's
+            // opponent slot changes from outside the cycler (e.g. the SEATS
+            // thumb-strip calling SetOpponentBoardId). Without this the label
+            // goes stale after a thumb click.
+            if (_layout != null) _layout.LayoutChanged += Refresh;
             Refresh();
+        }
+
+        private void OnDestroy()
+        {
+            if (_layout != null) _layout.LayoutChanged -= Refresh;
         }
 
         public void Refresh()

--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/MultiBoardLayout.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/MultiBoardLayout.cs
@@ -7,15 +7,22 @@ namespace Magi.LedgeBoardGame.Board
     /// Positions BoardPresenter instances under the same parent. Supports two
     /// view modes:
     ///   - BirdsEye: grid (default; the only mode for &lt;= 4 seats).
-    ///   - Comparison: local seat's board fixed left, one opponent right,
-    ///     others hidden. Players cycle the right-side slot through the
-    ///     remaining opponents. Gives the player a useful focused view at
-    ///     6-8 seats where the grid becomes too dense.
+    ///   - Comparison: one board pinned left, one opponent right, others
+    ///     hidden. The left-slot policy is mode-dependent:
+    ///       Local  — left = this client's seat board (network play, where
+    ///                only one player drives this instance). The right slot
+    ///                auto-jumps to the active player's board when it isn't
+    ///                already this client's seat, so the in-progress turn is
+    ///                always on screen.
+    ///       Active — left = current-turn board (hot-seat practice, where
+    ///                the same instance drives every seat in rotation).
+    ///                Players cycle the right slot manually.
     /// </summary>
     [ExecuteAlways]
     public class MultiBoardLayout : MonoBehaviour
     {
         public enum ViewMode { BirdsEye, Comparison }
+        public enum LeftSlotPolicy { Local, Active }
 
         [SerializeField] private List<BoardPresenter> presenters = new List<BoardPresenter>();
         [SerializeField] private int columns = 2;
@@ -26,11 +33,34 @@ namespace Magi.LedgeBoardGame.Board
         [SerializeField] private float comparisonSlotX = 550f;
 
         private int _localBoardId = -1;
+        private int _activeBoardId = -1;
         private int _comparisonOpponentBoardId = -1;
+        private LeftSlotPolicy _leftSlotPolicy = LeftSlotPolicy.Local;
 
         public ViewMode Mode => mode;
         public int LocalBoardId => _localBoardId;
+        public int ActiveBoardId => _activeBoardId;
         public int CurrentOpponentBoardId => _comparisonOpponentBoardId;
+        public LeftSlotPolicy Policy => _leftSlotPolicy;
+
+        /// Fires after Refresh / opponent cycle / mode toggle / active-board
+        /// change — anything that might require chrome (thumbnail strip,
+        /// BoardViewHud) to re-render. Subscribe in chrome Initialize, drop
+        /// the subscription in OnDestroy.
+        public event System.Action LayoutChanged;
+        public int ComparisonLeftBoardId =>
+            _leftSlotPolicy == LeftSlotPolicy.Active && _activeBoardId >= 0
+                ? _activeBoardId
+                : _localBoardId;
+
+        public void SetLeftSlotPolicy(LeftSlotPolicy policy)
+        {
+            if (_leftSlotPolicy == policy) return;
+            _leftSlotPolicy = policy;
+            EnsurePresenters();
+            ResolveOpponentIfNeeded();
+            if (mode == ViewMode.Comparison) Refresh();
+        }
 
         public void SetLocalBoardId(int boardId)
         {
@@ -40,11 +70,52 @@ namespace Magi.LedgeBoardGame.Board
             // the very first SetLocalBoardId call finds no opponent and the
             // right-hand slot comes up blank on the first Compare toggle.
             EnsurePresenters();
-            if (_comparisonOpponentBoardId == _localBoardId || _comparisonOpponentBoardId < 0)
-            {
-                _comparisonOpponentBoardId = FindFirstOpponentBoardId();
-            }
+            ResolveOpponentIfNeeded();
             Refresh();
+        }
+
+        /// Track the current-turn board. Under the Local policy the right
+        /// slot auto-follows the active board so a network client always
+        /// sees the player whose turn it is. Under the Active policy the
+        /// left slot follows instead.
+        public void SetActiveBoardId(int boardId)
+        {
+            if (_activeBoardId == boardId) return;
+            int prevLeftId = ComparisonLeftBoardId;
+            _activeBoardId = boardId;
+            EnsurePresenters();
+            // Local policy (network play): right slot tracks the active
+            // board whenever it differs from the local seat. When it's our
+            // own turn, leave the right slot wherever the player parked it
+            // — we don't want to blank out an opponent they were studying.
+            if (_leftSlotPolicy == LeftSlotPolicy.Local
+                && _activeBoardId >= 0
+                && _activeBoardId != _localBoardId)
+            {
+                _comparisonOpponentBoardId = _activeBoardId;
+            }
+            // Active policy (hot-seat practice): when the rotating left slot
+            // collides with whatever was on the right, swap — the just-
+            // finished player moves to the right slot, so the player whose
+            // turn just ended stays visible next to the new active player.
+            else if (_leftSlotPolicy == LeftSlotPolicy.Active
+                     && _comparisonOpponentBoardId == _activeBoardId
+                     && prevLeftId >= 0
+                     && prevLeftId != _activeBoardId)
+            {
+                _comparisonOpponentBoardId = prevLeftId;
+            }
+            ResolveOpponentIfNeeded();
+            if (mode == ViewMode.Comparison) Refresh();
+        }
+
+        private void ResolveOpponentIfNeeded()
+        {
+            int leftId = ComparisonLeftBoardId;
+            if (_comparisonOpponentBoardId == leftId || _comparisonOpponentBoardId < 0)
+            {
+                _comparisonOpponentBoardId = FindFirstNonLeftBoardId(leftId);
+            }
         }
 
         public void SetViewMode(ViewMode newMode)
@@ -65,11 +136,12 @@ namespace Magi.LedgeBoardGame.Board
         public void CycleOpponent(int dir)
         {
             EnsurePresenters();
+            int leftId = ComparisonLeftBoardId;
             var ids = new List<int>();
             foreach (var p in presenters)
             {
                 if (p == null || p.BoardState == null) continue;
-                if (p.BoardState.BoardId == _localBoardId) continue;
+                if (p.BoardState.BoardId == leftId) continue;
                 ids.Add(p.BoardState.BoardId);
             }
             if (ids.Count == 0) return;
@@ -91,17 +163,32 @@ namespace Magi.LedgeBoardGame.Board
             Refresh();
         }
 
+        /// Force opponent slot to a specific board (thumbnail strip
+        /// direct-jump). No-op if the target is the left slot — left and
+        /// right can't be the same board. Refresh + LayoutChanged fire
+        /// only when the value actually changes.
+        public void SetOpponentBoardId(int boardId)
+        {
+            if (boardId == ComparisonLeftBoardId) return;
+            if (boardId == _comparisonOpponentBoardId) return;
+            _comparisonOpponentBoardId = boardId;
+            if (mode == ViewMode.Comparison) Refresh();
+            else LayoutChanged?.Invoke();
+        }
+
         [ContextMenu("Refresh Layout")]
         public void Refresh()
         {
             EnsurePresenters();
-            if (mode == ViewMode.Comparison && _localBoardId >= 0 && presenters.Count >= 2)
+            if (mode == ViewMode.Comparison && ComparisonLeftBoardId >= 0 && presenters.Count >= 2)
                 ApplyComparisonLayout();
             else
                 ApplyBirdsEyeLayout();
 
             var panZoom = GetComponent<MultiBoardPanZoom>();
             if (panZoom != null) panZoom.RequestFit();
+
+            LayoutChanged?.Invoke();
         }
 
         private void EnsurePresenters()
@@ -112,12 +199,12 @@ namespace Magi.LedgeBoardGame.Board
             }
         }
 
-        private int FindFirstOpponentBoardId()
+        private int FindFirstNonLeftBoardId(int leftId)
         {
             foreach (var p in presenters)
             {
                 if (p == null || p.BoardState == null) continue;
-                if (p.BoardState.BoardId != _localBoardId) return p.BoardState.BoardId;
+                if (p.BoardState.BoardId != leftId) return p.BoardState.BoardId;
             }
             return -1;
         }
@@ -157,16 +244,17 @@ namespace Magi.LedgeBoardGame.Board
 
         private void ApplyComparisonLayout()
         {
+            int leftId = ComparisonLeftBoardId;
             foreach (var presenter in presenters)
             {
                 if (presenter == null || presenter.BoardState == null) continue;
                 int id = presenter.BoardState.BoardId;
-                bool isLocal = id == _localBoardId;
+                bool isLeft = id == leftId;
                 bool isOpponent = id == _comparisonOpponentBoardId;
-                presenter.gameObject.SetActive(isLocal || isOpponent);
-                if (!isLocal && !isOpponent) continue;
+                presenter.gameObject.SetActive(isLeft || isOpponent);
+                if (!isLeft && !isOpponent) continue;
 
-                var pos = new Vector2(isLocal ? -comparisonSlotX : comparisonSlotX, 0f);
+                var pos = new Vector2(isLeft ? -comparisonSlotX : comparisonSlotX, 0f);
                 var rect = presenter.GetComponent<RectTransform>();
                 if (rect != null) rect.anchoredPosition = pos;
                 else presenter.transform.localPosition = pos;

--- a/LedgeBoardGame/Assets/_Project/Scripts/Scripts/GameController.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Scripts/GameController.cs
@@ -987,24 +987,50 @@ namespace Magi.LedgeBoardGame
         }
 
         private Board.BoardViewHud _boardViewHud;
+        private Board.BoardThumbStrip _boardThumbStrip;
         private void EnsureBoardViewHud()
         {
-            if (_boardViewHud != null) { _boardViewHud.Refresh(); return; }
-            if (multiBoardLayout == null) return;
-            var canvas = GetComponentInParent<Canvas>();
-            if (canvas == null)
+            var canvas = ResolveBoardChromeCanvas();
+            if (canvas == null || multiBoardLayout == null) return;
+
+            if (_boardViewHud != null)
             {
-                foreach (var presenter in _boardPresenters.Values)
-                {
-                    canvas = presenter.GetComponentInParent<Canvas>();
-                    if (canvas != null) break;
-                }
+                _boardViewHud.Refresh();
             }
-            if (canvas == null) return;
-            var go = new GameObject("BoardViewHudHost");
-            go.transform.SetParent(canvas.transform, false);
-            _boardViewHud = go.AddComponent<Board.BoardViewHud>();
-            _boardViewHud.Initialize(multiBoardLayout);
+            else
+            {
+                var go = new GameObject("BoardViewHudHost");
+                go.transform.SetParent(canvas.transform, false);
+                _boardViewHud = go.AddComponent<Board.BoardViewHud>();
+                _boardViewHud.Initialize(multiBoardLayout);
+            }
+
+            // 6-8 seat SEATS strip (bottom-center, above the StatusLog chrome).
+            // Gated internally by BoardThumbStrip.ShouldShow(); at <=5 seats it
+            // simply stays hidden and the BoardViewHud cycler covers navigation.
+            if (_boardThumbStrip != null)
+            {
+                _boardThumbStrip.UpdateGameState(_gameState);
+            }
+            else
+            {
+                var stripHost = new GameObject("BoardThumbStripHost");
+                stripHost.transform.SetParent(canvas.transform, false);
+                _boardThumbStrip = stripHost.AddComponent<Board.BoardThumbStrip>();
+                _boardThumbStrip.Initialize(multiBoardLayout, _gameState);
+            }
+        }
+
+        private Canvas ResolveBoardChromeCanvas()
+        {
+            var canvas = GetComponentInParent<Canvas>();
+            if (canvas != null) return canvas;
+            foreach (var presenter in _boardPresenters.Values)
+            {
+                canvas = presenter.GetComponentInParent<Canvas>();
+                if (canvas != null) return canvas;
+            }
+            return null;
         }
 
         private void OnSpaceClicked(SpaceView view)


### PR DESCRIPTION
## Summary

- Adds a gated bottom-center `SEATS N` thumbnail strip for 6+ player comparison mode.
- Adds direct opponent-board selection from the strip and refreshes the existing top-right BoardView HUD when comparison state changes.
- Preserves the previously merged BoardView HUD containment fix (`childControlWidth = true`).

## Scope

Touched only:

- `LedgeBoardGame/Assets/_Project/Scripts/Board/BoardThumbStrip.cs`
- `LedgeBoardGame/Assets/_Project/Scripts/Board/BoardThumbStrip.cs.meta`
- `LedgeBoardGame/Assets/_Project/Scripts/Board/BoardViewHud.cs`
- `LedgeBoardGame/Assets/_Project/Scripts/Board/MultiBoardLayout.cs`
- `LedgeBoardGame/Assets/_Project/Scripts/Scripts/GameController.cs`

Explicitly excluded local reference/import dirs:

- `kit-import/`
- `kit-import-v6/`

## Verification

- `git diff --check`: passed pre- and post-commit.
- Unity compile/runtime probes: passed.
- Final Unity state after verification: Play mode false, compiling false, console 0 errors / 0 warnings.
- 3-seat regression: strip hidden; accepted practice HUD unchanged.
- 6-seat and 8-seat captures: strip visible, contained, clears StatusLog and ActionBar.
- Actual `Button.onClick` path verified for thumb selection.
- Synthetic 720px narrow-canvas probe verified clamped root width for 8 seats.
- Claude Design reviewed the uploaded handoff and returned `approve_with_notes` with no blockers.
- Folded in Claude Design’s only recommended pre-commit item: stronger/lower-tracking `SEATS N` label.

## Review notes

- Gemini source closure: approve.
- Codex source closure: approve_with_notes, no blockers.
- Claude Design carry-forward polish left out of this slice:
  - lower-board/nameplate overlap/elevation pass,
  - unselected chip swatch contrast,
  - future compact/scrolling variant if seat counts exceed 8.
