### PR TITLE
style(ledge): polish comparison seats strip

### DIFF
--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardThumbStrip.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardThumbStrip.cs
@@ -273,7 +273,10 @@ namespace Magi.LedgeBoardGame.Board
             le.preferredHeight = 38f;
 
             var hl = go.GetComponent<HorizontalLayoutGroup>();
-            hl.padding = new RectOffset(8, 12, 7, 7);
+            // Symmetric horizontal padding so the tray reads intentional at
+            // both 6 and 8 seats (was 8/12 asymmetric — the extra right pad
+            // looked reactive against the compact 8-seat thumb width).
+            hl.padding = new RectOffset(10, 10, 7, 7);
             hl.spacing = 8f;
             hl.childAlignment = TextAnchor.MiddleLeft;
             hl.childControlWidth = false;
@@ -291,7 +294,11 @@ namespace Magi.LedgeBoardGame.Board
             var chipRt = (RectTransform)chipGo.transform;
             chipRt.sizeDelta = new Vector2(22f, 22f);
             var chipImg = chipGo.GetComponent<Image>();
-            chipImg.color = new Color(0.10f, 0.12f, 0.22f, 1f);
+            // Placeholder swatch lifted well above the tray/thumb fill
+            // (LedgeUITokens.Panel is ~0.08 luma) so the unselected chip
+            // reads as a distinct element until the skin catalog supplies
+            // the player's real colour. Paired with a brighter edge below.
+            chipImg.color = new Color(0.22f, 0.26f, 0.42f, 1f);
             chipImg.raycastTarget = false;
             var chipOutline = chipGo.GetComponent<Outline>();
             chipOutline.effectColor = LedgeUITokens.PanelEdge2;
@@ -321,10 +328,13 @@ namespace Magi.LedgeBoardGame.Board
             TMP_Text caption = null;
             if (isLocal)
             {
+                // Quiet but legible at compact thumb widths: a touch larger,
+                // lighter tracking, and InkFaint (0.62) instead of InkDim
+                // (0.40) so "YOU" doesn't read as clipped/washed out.
                 caption = MakeText(textCol.transform, "Caption", LedgeUITokens.MonoFont,
-                    8f, LedgeUITokens.InkDim, "YOU");
+                    9f, LedgeUITokens.InkFaint, "YOU");
                 caption.fontStyle = FontStyles.UpperCase;
-                caption.characterSpacing = 16f;
+                caption.characterSpacing = 8f;
                 caption.alignment = TextAlignmentOptions.MidlineLeft;
             }
 


### PR DESCRIPTION
## Summary

- Polishes the cp047 comparison `SEATS N` strip in `BoardThumbStrip.cs` only.
- Balances compact thumb padding for 6- and 8-seat rows.
- Raises the placeholder skin-swatch fill so unselected chips read against the dark tray.
- Makes the local `YOU` caption quiet but more legible at compact thumb widths.

## Scope

Tracked changed file:

```text
LedgeBoardGame/Assets/_Project/Scripts/Board/BoardThumbStrip.cs
```

Explicitly untouched/unstaged:

```text
kit-import/
kit-import-v6/
```

## Verification

Source/git:

- `git diff --check`: pass before commit and post-commit.
- Commit scope: one file only.
- Post-commit working tree: clean except excluded untracked `kit-import/`, `kit-import-v6/`.

Unity/runtime:

- Unity compile/execution probes: successful.
- Final Unity console: `0` errors / `0` warnings.
- Final Play-mode probe: `play=False`, `compiling=False`.
- 3-seat metric: strip hidden, `thumbs=0`.
- 6-seat metric: strip visible, `thumbs=6`, active swatch `RGBA(0.220, 0.260, 0.420, 1.000)`, `YOU` is `InkFaint`, size `9`, spacing `8`.
- 8-seat metric: strip visible, `thumbs=8`, active swatch `RGBA(0.220, 0.260, 0.420, 1.000)`, `YOU` is `InkFaint`, size `9`, spacing `8`.

Review:

- Gemini source review: approve.
- Codex source review: approve.
- Claude Design metrics-only review: approve.

## Screenshot caveat / follow-up

Fresh gameplay screenshots could not be recaptured through the Unity MCP tool surface after this constants-only polish. Capture attempts via `ScreenCapture`, `ReadPixels`, offscreen UI camera, and camera capture failed through MCP/tool constraints. Reviewers accepted source diff + runtime metrics as sufficient for this slice.

Carry-forward visual follow-up from Claude Design:

- Opportunistically capture real gameplay pixels later to confirm the brighter placeholder swatch does not compete with the gold active-seat state.
- Keep the still-open `SEATS N` header-label contrast item on the next visual pass list.
