### PR TITLE
feat(ledge): compact You panel in comparison view

### DIFF
--- a/LedgeBoardGame/Assets/_Project/Scripts/Scripts/GameController.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Scripts/GameController.cs
@@ -863,6 +863,11 @@ namespace Magi.LedgeBoardGame
         private void OnDestroy()
         {
             SpaceClickedEvent.Unregister(OnSpaceClicked);
+            if (_youPanelLayoutSub != null)
+            {
+                _youPanelLayoutSub.LayoutChanged -= RefreshYouPanelCompactMode;
+                _youPanelLayoutSub = null;
+            }
             if (_shadowSink != null)
             {
                 UnsubscribeObserver(_shadowSink);
@@ -922,6 +927,17 @@ namespace Magi.LedgeBoardGame
                 int localBoardId = ResolveLocalBoardId();
                 multiBoardLayout.SetLocalBoardId(localBoardId);
                 multiBoardLayout.Refresh();
+
+                // Re-fit the You panel whenever the view mode / comparison slots
+                // change. CreateBoardPresenters runs from more than one path, so
+                // detach first: -= then += is idempotent and can't double-subscribe.
+                // Keep the exact instance we subscribed to so OnDestroy detaches
+                // from it even if `multiBoardLayout` is later reassigned.
+                if (_youPanelLayoutSub != null && _youPanelLayoutSub != multiBoardLayout)
+                    _youPanelLayoutSub.LayoutChanged -= RefreshYouPanelCompactMode;
+                multiBoardLayout.LayoutChanged -= RefreshYouPanelCompactMode;
+                multiBoardLayout.LayoutChanged += RefreshYouPanelCompactMode;
+                _youPanelLayoutSub = multiBoardLayout;
             }
 
             EnsureBoardViewHud();
@@ -929,6 +945,7 @@ namespace Magi.LedgeBoardGame
 
             gameHud?.UpdateHud(_gameState);
             _youPanel?.UpdateFromState(_gameState, _localSeatId, networkMode == NetworkMode.Network);
+            RefreshYouPanelCompactMode();
         }
 
         /// Register each board with the dream canvas so a corona ring + core
@@ -1830,6 +1847,9 @@ namespace Magi.LedgeBoardGame
 
         private LedgeDreamCanvas _dreamCanvas;
         private LedgeYouPanel _youPanel;
+        // The exact MultiBoardLayout instance we attached RefreshYouPanelCompactMode
+        // to, so OnDestroy detaches from that one even if the field is reassigned.
+        private Board.MultiBoardLayout _youPanelLayoutSub;
         private LedgeActionBar _actionBar;
         private LedgeEndOfGamePanel _endOfGamePanel;
         private bool _endOfGameShown;
@@ -1856,6 +1876,29 @@ namespace Magi.LedgeBoardGame
             go.transform.SetParent(canvas.transform, false);
             go.transform.SetAsLastSibling();
             _youPanel = go.AddComponent<LedgeYouPanel>();
+        }
+
+        /// Slim the You panel in Comparison view at 3+ seats so the full 2P
+        /// chrome stops competing with the SEATS strip. Driven both by
+        /// MultiBoardLayout.LayoutChanged (view-mode / slot changes) and by the
+        /// You-panel state-refresh path, since the seat count can change without
+        /// a layout event (join/leave in progress).
+        private void RefreshYouPanelCompactMode()
+        {
+            if (_youPanel == null) return;
+            bool compact = multiBoardLayout != null
+                && multiBoardLayout.Mode == Board.MultiBoardLayout.ViewMode.Comparison
+                && (_gameState?.Boards?.Count ?? 0) >= 3;
+            _youPanel.SetCompactMode(compact);
+
+            // Re-push state AFTER the flag flips. The section caption is built in
+            // UpdateFromState behind an `if (_compact)` branch, so without this the
+            // caption lags a mode change: entering Comparison would hide the turn
+            // row while the caption still read "CURRENT PLAYER" (leaving no turn
+            // info at all), and leaving it would strand a stale "TURN N · …".
+            // UpdateFromState never raises LayoutChanged, so this cannot recurse.
+            if (_gameState != null)
+                _youPanel.UpdateFromState(_gameState, _localSeatId, networkMode == NetworkMode.Network);
         }
 
         /// Build the bottom-left action belt and fold the existing scene-

--- a/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeYouPanel.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeYouPanel.cs
@@ -25,7 +25,34 @@ namespace Magi.LedgeBoardGame.UI
         private TMP_Text _turnLabel;
         private TMP_Text _statusLabel;
 
+        private bool _compact;
+
+        // Full chrome vs the slim Comparison-view variant. Compact drops the
+        // turn/status rows (their content folds into the section caption), so
+        // the panel stops crowding the SEATS strip at 3+ seats.
+        private const float PanelWidth = 360f;
+        private const float FullHeight = 130f;
+        private const float CompactHeight = 70f;
+
         private void Awake() => EnsureBuilt();
+
+        /// Slim the top-left panel for Comparison view at 3+ seats. Keeps the
+        /// section caption + identity row and folds the turn line into the
+        /// caption (see UpdateFromState). Full mode is unchanged.
+        public void SetCompactMode(bool compact)
+        {
+            EnsureBuilt();
+            // Apply size + visibility unconditionally rather than early-returning
+            // when the flag is unchanged: the assignments are idempotent, and
+            // re-asserting them means compact state can't silently desync if
+            // anything else touches the rect or those labels.
+            _compact = compact;
+
+            var rt = (RectTransform)transform;
+            rt.sizeDelta = new Vector2(PanelWidth, _compact ? CompactHeight : FullHeight);
+            if (_turnLabel != null) _turnLabel.gameObject.SetActive(!_compact);
+            if (_statusLabel != null) _statusLabel.gameObject.SetActive(!_compact);
+        }
 
         public void EnsureBuilt()
         {
@@ -163,6 +190,16 @@ namespace Magi.LedgeBoardGame.UI
             string activeName = state.GetCurrentPlayer()?.Name ?? $"Player {currentId}";
             _turnLabel.text = itsYourTurn ? "Your turn." : $"{activeName}'s turn.";
             _turnLabel.color = itsYourTurn ? LedgeUITokens.Accent : LedgeUITokens.Ink;
+
+            // Compact mode hides the turn row, so fold the turn line into the
+            // section caption instead. The full-mode caption set above is left
+            // exactly as-is; this only overrides it when compact.
+            if (_compact)
+            {
+                _sectionLabel.text = itsYourTurn
+                    ? $"TURN {state.TurnNumber} · YOUR MOVE"
+                    : $"TURN {state.TurnNumber} · {activeName.ToUpperInvariant()}'S MOVE";
+            }
 
             // Status / phase guidance
             string statusStr;


### PR DESCRIPTION
## Summary
- Compact the top-left You panel in 3+ seat Comparison view so it no longer competes with the SEATS strip.
- Fold turn information into the compact caption and refresh it immediately when entering/leaving Comparison.
- Preserve the existing wedge-dot identity UI; no skin-chip/takeback/settings/visitor/endgame/strip/HUD changes.

## Verification
- `git diff --check`
- Forbidden added-line grep for takeback/settings/visitor/skin/endgame/strip/HUD symbols returned no matches.
- Identity preservation grep for wedge-dot/skin-chip symbols returned no matches.
- Codex closure review: approve_with_notes, no blockers.
- Unity runtime verification: correct LedgeBoardGame binding, fixed build compiled, 0 errors / 0 warnings, `isCompiling=False`.
- Runtime verified caption updates immediately entering/leaving Comparison.
- Runtime verified 2-seat Comparison stays full, 6-seat Comparison compacts to 360×70, no clipping in landscape/portrait.
- Regression guards pass for SEATS strip and BoardViewHud containment.
- Claude Design review: approve_with_notes, no blockers.

## Notes / follow-up
- Gemini/agy review lane waived by Lake for CP052 due quota block.
- Exact 3-seat boundary not literally captured; 2-seat and 6-seat bracket the `>=3` gate.
- Future polish: portrait micro-caps legibility, long-name caption ellipsis, pre-existing StatusLog/nameplate overlap, and broader portrait Comparison polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)