### PR TITLE
feat(ledge): activate local visitor overlays

### DIFF
--- a/LedgeBoardGame/Assets/_Project/Scripts/Scripts/GameController.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Scripts/GameController.cs
@@ -1124,6 +1124,54 @@ namespace Magi.LedgeBoardGame
             return transform;
         }
 
+        /// Cross-board visitor overlay is active in Local/hot-seat mode only.
+        /// At most one visitor overlay is visible at a time: every successful
+        /// Local move — cross-board or same-board — first clears whatever a
+        /// prior move this turn left showing (via ClearAllVisitorStates),
+        /// then cross-board moves mark the final landing tile on the host
+        /// board. The overlay persists (it is NOT tied to the move's tween
+        /// being "in flight") until the next clear point: another successful
+        /// Local move, undo, turn rotation, or game over. Network mode is
+        /// intentionally not wired: remote moves apply via
+        /// ApplyServerStateAndRefresh, which carries no from/to action data.
+        ///
+        /// MVP simplification: for a multi-hop move this marks only the final
+        /// landing tile, not every intermediate hop.
+        private void TryShowCrossBoardVisitor(SpaceId from, SpaceId to)
+        {
+            if (networkMode != NetworkMode.Local) return;
+
+            // One-active-overlay semantics: clear before optionally setting
+            // so a second cross-board move (to a different host board) or a
+            // same-board move never leaves a prior board's pill/glow stuck.
+            ClearAllVisitorStates();
+
+            if (from.BoardId == to.BoardId) return;
+            if (!_boardPresenters.TryGetValue(to.BoardId, out var hostPresenter) || hostPresenter == null) return;
+
+            var visitor = _gameState?.GetCurrentPlayer();
+            if (visitor == null) return;
+
+            // Seat-indexed, not the PlayerPrefs skin — every hot-seat visitor must
+            // render a distinct accent so the host can tell who is acting on their
+            // board (isLocal: false here on purpose, even though this player is
+            // the one physically at the keyboard in hot-seat).
+            var accent = LedgeSkinCatalog.GetAccentForPlayer(visitor.Id, isLocal: false);
+            hostPresenter.SetVisitor(visitor.Name, accent, to.Id);
+        }
+
+        /// Null-safe, idempotent: safe to call from every rewind/terminal point
+        /// (turn rotation, undo, game over) or from TryShowCrossBoardVisitor
+        /// itself without checking whether a visitor overlay is currently
+        /// showing.
+        private void ClearAllVisitorStates()
+        {
+            foreach (var presenter in _boardPresenters.Values)
+            {
+                presenter?.ClearVisitor();
+            }
+        }
+
         private void OnMoveTweenComplete()
         {
             _moveInProgress = false;
@@ -1526,6 +1574,8 @@ namespace Magi.LedgeBoardGame
             {
                 LogEvent($"{mover.Name} moved {FormatStackCounts(lightMoved, darkMoved)}: {FormatSpace(from)} → {FormatSpace(animationEnd)}");
             }
+            // Local/hot-seat only — see TryShowCrossBoardVisitor's contract.
+            TryShowCrossBoardVisitor(from, animationEnd);
             ClearMovementSelection();
             UpdateStatusUI();
             if (fromView != null)
@@ -2156,6 +2206,10 @@ namespace Magi.LedgeBoardGame
                 if (!_endOfGameShown)
                 {
                     _endOfGameShown = true;
+                    // Game over skips MaybeSignalPhaseBanner's early-return path
+                    // entirely, so the visitor pill/glow would otherwise strand
+                    // under the endgame takeover veil.
+                    ClearAllVisitorStates();
                     ShowEndOfGameTakeover(winnerName);
                 }
             }
@@ -2549,6 +2603,14 @@ namespace Magi.LedgeBoardGame
 
             var endOfTurn = _gameState.EndTurn();
             NarrateOverflowCap(endOfTurn, endingPlayer);
+            if (endOfTurn.GameEnded)
+            {
+                // MaybeSignalPhaseBanner (invoked below via UpdateStatusUI) early-
+                // returns once _gameState.GameOver is true, so an end-turn
+                // overflow/elimination that ends the game on this local path
+                // would otherwise never clear the visitor overlay.
+                ClearAllVisitorStates();
+            }
             var nextPlayer = _gameState.GetCurrentPlayer();
             _shadowSink?.ShadowEndTurn(endingSeatIndex, BuildCurrentSpecState());
 
@@ -2748,6 +2810,10 @@ namespace Magi.LedgeBoardGame
 
         private void ApplyUndoState(GameState snapshot)
         {
+            // Undo can rewind a cross-board visitor without rotating the turn,
+            // so MaybeSignalPhaseBanner's phase/player dedup would never fire —
+            // clear explicitly rather than relying on that path.
+            ClearAllVisitorStates();
             _gameState.CopyFrom(snapshot);
             RefreshBoards();
             UpdateStatusUI();
@@ -2829,6 +2895,13 @@ namespace Magi.LedgeBoardGame
 
             _lastSignaledPhase = currentPhase;
             _lastSignaledPlayerId = currentPlayerId;
+
+            // Turn/phase actually rotated — clear any cross-board visitor
+            // overlay from the move that just happened. This early-return
+            // above (unchanged phase+player, or GameOver) means this is NOT
+            // a robust catch-all by itself; ApplyUndoState and the game-over
+            // takeover path each clear explicitly too.
+            ClearAllVisitorStates();
 
             // Active-board glow follows the current player's turn.
             UpdateDreamCanvasActiveBoard();

--- a/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeSkinCatalog.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeSkinCatalog.cs
@@ -1,0 +1,53 @@
+using UnityEngine;
+
+namespace Magi.LedgeBoardGame.UI
+{
+    /// Resolves a player's board skin to the cool accent color used by the
+    /// cross-board visitor overlay (Local/hot-seat mode only - see
+    /// GameController.TryShowCrossBoardVisitor). Local player's skin comes
+    /// from PlayerPrefs (the lobby owns this); non-local players have no
+    /// propagated skin yet, so we fall back to a stable seat-indexed pick
+    /// into the skin catalog. When a SetBoardSkin network action ships,
+    /// swap the fallback for the propagated value.
+    public static class LedgeSkinCatalog
+    {
+        public const string SkinPrefKey = "ledge.boardSkin";
+        public const string DefaultSkinId = "nightfall";
+
+        /// Resolve the skin for a player ID (1-based per Player.Id).
+        /// isLocal: true if this is the client's own seat (in network
+        /// mode). Local seats read from PlayerPrefs; non-local seats -
+        /// including every hot-seat visitor - fall back to the
+        /// seat-indexed catalog pick so each seat renders a visually
+        /// distinct accent.
+        public static LedgeSetupPanel.SkinDef GetSkinForPlayer(int playerId, bool isLocal)
+        {
+            if (isLocal)
+            {
+                string id = PlayerPrefs.GetString(SkinPrefKey, DefaultSkinId);
+                if (string.IsNullOrEmpty(id)) id = DefaultSkinId;
+                var resolved = TryFindSkin(id);
+                if (resolved.HasValue) return resolved.Value;
+            }
+            // Seat-indexed fallback: stable, distinguishable, no network
+            // dependency. Player IDs are 1-based; clamp defensively before
+            // wrapping into the catalog length.
+            int idx = Mathf.Max(0, playerId - 1) % LedgeSetupPanel.DefaultSkins.Length;
+            return LedgeSetupPanel.DefaultSkins[idx];
+        }
+
+        /// Convenience overload - returns the cool accent color directly.
+        public static Color GetAccentForPlayer(int playerId, bool isLocal)
+        {
+            return GetSkinForPlayer(playerId, isLocal).Accent;
+        }
+
+        private static LedgeSetupPanel.SkinDef? TryFindSkin(string id)
+        {
+            var skins = LedgeSetupPanel.DefaultSkins;
+            for (int i = 0; i < skins.Length; i++)
+                if (skins[i].Id == id) return skins[i];
+            return null;
+        }
+    }
+}

--- a/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeSkinCatalog.cs.meta
+++ b/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeSkinCatalog.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 09e2e5b0cf0eb844d8e16f39cfc3bfd4


### PR DESCRIPTION
## Summary

Activates the already-landed (PR #3) cross-board visitor overlay for **Local/hot-seat mode only**. Network mode is intentionally not wired: remote authoritative state echoes apply via `ApplyServerStateAndRefresh`, which carries no `from`/`to` action data.

## Behavior contract

- Cross-board Local moves clear any previous visitor overlay, then mark the final landing tile on the destination board.
- Same-board moves clear any prior visitor overlay and show nothing (at most one overlay is ever visible at a time).
- The overlay clears on: the next successful Local move, undo/state replace (`ApplyUndoState`), turn rotation, and game-over (both the animation-tween game-over path and the local end-turn overflow/elimination game-over path).
- Seat-indexed accents (`LedgeSkinCatalog`, `isLocal: false`) keep hot-seat visitors visually distinct from one another.
- Multi-hop moves mark only the final landing tile (documented MVP simplification).

## Changes

- `LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeSkinCatalog.cs` (new) — cleaned skin/accent resolver: `GetSkinForPlayer`/`GetAccentForPlayer(playerId, isLocal)`, PlayerPrefs for the local seat, seat-indexed fallback otherwise.
- `LedgeBoardGame/Assets/_Project/Scripts/Scripts/GameController.cs` — adds `TryShowCrossBoardVisitor`/`ClearAllVisitorStates`, wires activation into the Local move path, and wires clearing into `MaybeSignalPhaseBanner`, `ApplyUndoState`, the game-over takeover path, and the local `OnEndTurnClicked` game-ended path.

## Review gates closed

- **Codex** (two passes, including a same-turn-stale-overlay fix and an end-turn game-over clear fix): no blocking issues remaining.
- **Unity runtime/visual** (injected lifecycle probe): correct project binding, 0 compile errors (1 unrelated MCP/codex-signature warning), 6 active boards, clear-all → 0 pills, `SetVisitor` → 1 pill, clear → 0, second `SetVisitor` → 1 pill with correctly scraped label; gameplay screenshot captured.
- **Claude Design**: `approve_with_notes`, no visual blockers, safe to merge with notes carried forward (below).

## Design notes carried forward (follow-up visual pass, not this PR)

All of the following require editing `BoardPresenter.cs`/`SpaceView.cs`, which are hard-excluded from this change (they protect PR #3/CP052 and must stay byte-identical):

- Visitor pill text wraps (`...acting / here`) — make it one line; consider shorter copy (`{Name} is acting` or `{Name}'s move`).
- Pill needs a designed minimum clearance from the Current Player panel (pill is board-anchored per source — this is spacing, not re-anchoring).
- Pill type scale is at the legibility floor — consider bumping size.
- Accent shape is inconsistent (square pill swatch vs. hex tile ring) — unify shape language.
- Magenta ring is a color-only cue — add a secondary signal (pulse, matching pill border) for color-limited players.
- Verify portrait 720×1280 and long-name stress cases.
- Run a real non-injected cross-board move validation when feasible — current runtime proof is a public-API injected-state probe plus source-reviewed trigger wiring.

## Test plan

- [x] Source verification: exact 3-file diff, `git diff --check` clean, forbidden-symbol grep (Takeback/SettingsPanel/LedgeEndOfGamePanel/BoardThumbStrip/BoardViewHud/MultiBoardPanZoom/StatusLog) clean, zero diff to `LedgeYouPanel.cs`/`BoardPresenter.cs`/`SpaceView.cs`/etc.
- [x] Unity compile/console clean (0 errors)
- [x] Injected visitor-overlay lifecycle probe (set/clear/set-different-host) in Play Mode
- [x] Claude Design visual review
- [ ] Real (non-injected) Local hot-seat cross-board move walkthrough in a full playtest
- [ ] Portrait capture with active visitor overlay
- [ ] Long real-name pill width / Current Player panel clearance check

🤖 Generated with [Claude Code](https://claude.com/claude-code)