### PR TITLE
style(ledge): polish visitor overlay chrome

### DIFF
--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardPresenter.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardPresenter.cs
@@ -38,9 +38,12 @@ namespace Magi.LedgeBoardGame.Board
         private TMP_Text _nameplateActiveCaption;
 
         // Control-handoff visitor chrome (CONTROL-HANDOFF-SPEC.md 2026-06-15):
-        // small pill above the board reading "<Name> is acting here" + a
-        // cool dot in the visitor's skin accent. Visible only while a
-        // visiting move is in flight on this board.
+        // small pill above the board reading "<Name> is acting" + a cool dot
+        // in the visitor's skin accent. Per CP053's Local/hot-seat contract,
+        // this stays visible until the next clear point (another Local move,
+        // undo, turn rotation, or game over) — it is NOT tied to a move
+        // being in flight; GameController owns exactly when Set/ClearVisitor
+        // are called.
         private GameObject _visitorPill;
         private Image _visitorPillDot;
         private TMP_Text _visitorPillName;
@@ -102,7 +105,7 @@ namespace Magi.LedgeBoardGame.Board
             ClearVisitorOverlayInternal();
             EnsureVisitorPill();
             if (_visitorPillName != null) _visitorPillName.text =
-                string.IsNullOrEmpty(visitorName) ? "Visitor is acting here" : $"{visitorName} is acting here";
+                string.IsNullOrEmpty(visitorName) ? "Visitor is acting" : $"{visitorName} is acting";
             if (_visitorPillDot != null) _visitorPillDot.color = visitorAccent;
             if (_visitorPill != null) _visitorPill.SetActive(true);
 
@@ -131,7 +134,8 @@ namespace Magi.LedgeBoardGame.Board
         }
 
         /// Glass pill anchored above the top of the board, sized to fit
-        /// "Name is acting here" at UI 12pt. Built once, reused by SetVisitor.
+        /// "Name is acting" on one line at UI 21pt. Built once, reused by
+        /// SetVisitor.
         private void EnsureVisitorPill()
         {
             if (_visitorPill != null) return;
@@ -145,7 +149,14 @@ namespace Magi.LedgeBoardGame.Board
             // Above the board — clear of the outermost ledge tiles (which sit
             // near ledgeRadius) so the pill never occludes the entry tile it
             // annotates. Sits higher than the nameplate's mirror distance below.
-            rt.anchoredPosition = new Vector2(0f, ledgeRadius + 90f);
+            // CP054: pushed further up (was ledgeRadius + 90f) for more
+            // clearance from screen-anchored chrome (e.g. the Current Player
+            // panel) that can sit near the top of the viewport — this is a
+            // board-space offset only, so it narrows but cannot fully
+            // guarantee clearance in every pan/zoom/layout combination; true
+            // collision-avoidance would need MultiBoardLayout awareness,
+            // which is out of this file's scope.
+            rt.anchoredPosition = new Vector2(0f, ledgeRadius + 130f);
 
             var bg = go.GetComponent<Image>();
             bg.color = LedgeUITokens.Panel;
@@ -167,27 +178,39 @@ namespace Magi.LedgeBoardGame.Board
             fitter.horizontalFit = ContentSizeFitter.FitMode.PreferredSize;
             fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
 
-            // Cool dot — visitor's skin accent.
-            var dotGo = new GameObject("Dot", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(LayoutElement));
+            // Cool dot — visitor's skin accent. Outlined to match the
+            // nameplate's skin-chip treatment (fill + thin edge) below the
+            // board, so the pill's identity swatch reads as part of the same
+            // chip family rather than a bare, borderless square (CP054).
+            var dotGo = new GameObject("Dot", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image), typeof(Outline), typeof(LayoutElement));
             dotGo.transform.SetParent(go.transform, false);
             var dotRt = (RectTransform)dotGo.transform;
             dotRt.sizeDelta = new Vector2(20f, 20f);
             _visitorPillDot = dotGo.GetComponent<Image>();
             _visitorPillDot.color = LedgeUITokens.AccentCool;
             _visitorPillDot.raycastTarget = false;
+            var dotOutline = dotGo.GetComponent<Outline>();
+            dotOutline.effectColor = LedgeUITokens.PanelEdge2;
+            dotOutline.effectDistance = new Vector2(LedgeUITokens.HairlineWidth, -LedgeUITokens.HairlineWidth);
             var dotLe = dotGo.GetComponent<LayoutElement>();
             dotLe.preferredWidth = 20f; dotLe.minWidth = 20f;
             dotLe.preferredHeight = 20f; dotLe.minHeight = 20f;
 
-            // "<Name> is acting here" UI bold 18pt.
+            // "<Name> is acting" UI bold 21pt, one line — no-wrap because the
+            // outer HorizontalLayoutGroup has childControlWidth=false and
+            // this Label's own RectTransform otherwise defaults to a fixed
+            // width, which combined with TMP's default word-wrap is exactly
+            // what produced CP053's "...acting / here" wrap. Disabling wrap
+            // here is the source-level fix rather than trimming copy alone.
             var nameGo = new GameObject("Label", typeof(RectTransform));
             nameGo.transform.SetParent(go.transform, false);
             _visitorPillName = nameGo.AddComponent<TextMeshProUGUI>();
             _visitorPillName.font = LedgeUITokens.UIFont;
-            _visitorPillName.fontSize = 18f;
+            _visitorPillName.fontSize = 21f;
             _visitorPillName.fontStyle = FontStyles.Bold;
             _visitorPillName.color = LedgeUITokens.Ink;
             _visitorPillName.alignment = TextAlignmentOptions.MidlineLeft;
+            _visitorPillName.textWrappingMode = TextWrappingModes.NoWrap;
             _visitorPillName.text = "Visitor";
             _visitorPillName.raycastTarget = false;
 

--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/SpaceView.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/SpaceView.cs
@@ -419,11 +419,18 @@ namespace Magi.LedgeBoardGame.Board
         // Lazily built so untouched tiles stay zero-cost.
         private Image _visitorOverlayImage;
         private Image _visitorHaloImage;
+        private Color _visitorHaloBaseColor;
+        private bool _visitorHaloActive;
 
         // The flat tint alone can't be told apart from a tile whose fill is
         // already near the visitor accent (many tiles are cyan/blue), so a
         // brighter accent ring around the entry tile carries the recognition.
-        private const float VisitorHaloAlpha = 0.8f;
+        // CP054: the ring also breathes slowly (see Update()) so the cue
+        // isn't color-alone — a shape/motion signal survives for
+        // color-limited players even if the accent hue is hard to place.
+        private const float VisitorHaloAlphaMin = 0.55f;
+        private const float VisitorHaloAlphaMax = 0.9f;
+        private const float VisitorHaloPulseHz = 0.45f;
 
         public void SetVisitorOverlay(Color accent, float alpha = 0.5f)
         {
@@ -435,17 +442,21 @@ namespace Magi.LedgeBoardGame.Board
             }
 
             // Accent halo carries the "someone is acting here" recognition on
-            // top of the translucent fill tint.
+            // top of the translucent fill tint. RGB is latched here; Update()
+            // drives the alpha breathe every frame while active.
             EnsureVisitorHaloImage();
             if (_visitorHaloImage != null)
             {
-                _visitorHaloImage.color = new Color(accent.r, accent.g, accent.b, VisitorHaloAlpha);
+                _visitorHaloBaseColor = accent;
+                _visitorHaloActive = true;
+                _visitorHaloImage.color = new Color(accent.r, accent.g, accent.b, VisitorHaloAlphaMax);
                 _visitorHaloImage.gameObject.SetActive(true);
             }
         }
 
         public void ClearVisitorOverlay()
         {
+            _visitorHaloActive = false;
             if (_visitorOverlayImage != null) _visitorOverlayImage.gameObject.SetActive(false);
             if (_visitorHaloImage != null) _visitorHaloImage.gameObject.SetActive(false);
         }
@@ -510,6 +521,19 @@ namespace Magi.LedgeBoardGame.Board
             go.SetActive(false);
         }
 
+        /// Slow alpha breathe on the visitor halo — quiet and distinct from
+        /// the faster valid-target pulse/movable-source breathe so at most
+        /// one visitor ring never competes with move-highlight chrome. Gives
+        /// the ring a motion cue independent of hue for color-limited players
+        /// (CP054 design follow-up), on top of the accent color itself.
+        private void TickVisitorHalo()
+        {
+            if (!_visitorHaloActive || _visitorHaloImage == null) return;
+            float t = Mathf.Sin(Time.unscaledTime * VisitorHaloPulseHz * 2f * Mathf.PI) * 0.5f + 0.5f;
+            float a = Mathf.Lerp(VisitorHaloAlphaMin, VisitorHaloAlphaMax, t);
+            _visitorHaloImage.color = new Color(_visitorHaloBaseColor.r, _visitorHaloBaseColor.g, _visitorHaloBaseColor.b, a);
+        }
+
         public void OnPointerClick(PointerEventData eventData)
         {
             onClicked?.Invoke(this);
@@ -541,6 +565,7 @@ namespace Magi.LedgeBoardGame.Board
         private void Update()
         {
             TickHoverLabelFade();
+            TickVisitorHalo();
 
             if (frameGlowImage == null) return;
 


### PR DESCRIPTION
## Summary
- Shortens visitor pill copy to `{Name} is acting` and keeps it on one line with TMP no-wrap at 21pt.
- Raises the board-anchored visitor pill for better clearance from Current Player chrome.
- Adds pill-dot outline to align with nameplate chip treatment.
- Adds slow visitor halo alpha breathe as a non-color cue while preserving CP053 Local/hot-seat visitor-overlay behavior.

## Verification
- `git diff --check`
- Unity compile/console: 0 errors from CP054 runtime checkpoint.
- Injected long-name visitor check: `Alexandria Montgomery-Whitfield is acting`, fontSize=21, `TextWrappingModes.NoWrap`, lineCount=1.
- Valid gameplay screenshot visually spot-checked by Hermes: `01-visitor-polish-gameplay-long-name.png`.
- Codex source review: approve_with_notes, no blockers.
- Gemini/agy: quota-blocked no verdict; waived by Lake for CP054.
- Claude Design: approve_with_notes, no visual blockers; CP053 pill notes closed.

## Carry-forward
- Live/burst-frame check of visitor halo pulse against active-board white glow; source floor is 0.55 alpha, max 0.9, 0.45Hz, so it never disappears.
- Capture visitor halo on a non-active board/no active glow.
- Portrait capture with active visitor once GameView sizing is available.
- Pathological very-long-name max-width/ellipsis or shrink-to-fit hardening.
- Further layout-aware clearance from screen-anchored HUD panels / Current Player chrome.
