### PR TITLE
feat(ledge): add Board View eyebrow and wrapping fix

### DIFF
--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardViewHud.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardViewHud.cs
@@ -72,7 +72,7 @@ namespace Magi.LedgeBoardGame.Board
             rootRect.anchorMax = new Vector2(1f, 1f);
             rootRect.pivot = new Vector2(1f, 1f);
             rootRect.anchoredPosition = new Vector2(-LedgeUITokens.PanelEdgeInset, -LedgeUITokens.PanelEdgeInset);
-            rootRect.sizeDelta = new Vector2(280f, 120f);
+            rootRect.sizeDelta = new Vector2(280f, 144f);
             rootRect.SetAsLastSibling();
 
             // Glass panel backdrop so this matches the TL/BL chrome.
@@ -83,15 +83,35 @@ namespace Magi.LedgeBoardGame.Board
             gRt.offsetMin = Vector2.zero;
             gRt.offsetMax = Vector2.zero;
 
-            // Toggle button — Primary variant (state-changing action), pinned to
-            // the top of the glass panel's content slot.
+            // Section label "BOARD VIEW" at the top — matches the mono
+            // section-caption convention used by the other chrome panels
+            // so this reads as part of the same panel family.
+            var labelHostGo = new GameObject("SectionLabel", typeof(RectTransform));
+            var sectionRt = (RectTransform)labelHostGo.transform;
+            sectionRt.SetParent(glass.Content, false);
+            sectionRt.anchorMin = new Vector2(0f, 1f);
+            sectionRt.anchorMax = new Vector2(1f, 1f);
+            sectionRt.pivot = new Vector2(0f, 1f);
+            sectionRt.anchoredPosition = Vector2.zero;
+            sectionRt.sizeDelta = new Vector2(0f, 14f);
+            var sectionLabel = labelHostGo.AddComponent<TextMeshProUGUI>();
+            sectionLabel.text = "BOARD VIEW";
+            sectionLabel.font = LedgeUITokens.MonoFont;
+            sectionLabel.fontSize = LedgeUITokens.SectionLabelSize;
+            sectionLabel.color = LedgeUITokens.InkDim;
+            sectionLabel.fontStyle = FontStyles.UpperCase;
+            sectionLabel.characterSpacing = 22f;
+            sectionLabel.alignment = TextAlignmentOptions.TopLeft;
+            sectionLabel.raycastTarget = false;
+
+            // Toggle button — Ghost variant, pinned beneath the section label.
             var toggleHost = new GameObject("Toggle", typeof(RectTransform));
             var toggleRt = (RectTransform)toggleHost.transform;
             toggleRt.SetParent(glass.Content, false);
             toggleRt.anchorMin = new Vector2(0f, 1f);
             toggleRt.anchorMax = new Vector2(1f, 1f);
             toggleRt.pivot = new Vector2(0.5f, 1f);
-            toggleRt.anchoredPosition = Vector2.zero;
+            toggleRt.anchoredPosition = new Vector2(0f, -20f);
             toggleRt.sizeDelta = new Vector2(0f, 36f);
             _toggleButton = toggleHost.AddComponent<LedgeButton>();
             _toggleButton.CurrentVariant = LedgeButton.Variant.Ghost;
@@ -105,7 +125,7 @@ namespace Magi.LedgeBoardGame.Board
             _comparisonGroup.anchorMin = new Vector2(0f, 1f);
             _comparisonGroup.anchorMax = new Vector2(1f, 1f);
             _comparisonGroup.pivot = new Vector2(0.5f, 1f);
-            _comparisonGroup.anchoredPosition = new Vector2(0f, -44f);
+            _comparisonGroup.anchoredPosition = new Vector2(0f, -64f);
             _comparisonGroup.sizeDelta = new Vector2(0f, 36f);
             var hl = _comparisonGroup.gameObject.AddComponent<HorizontalLayoutGroup>();
             hl.spacing = 8f;

--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/StatusLog.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/StatusLog.cs
@@ -96,7 +96,7 @@ namespace Magi.LedgeBoardGame.Board
             label.alignment = TextAlignmentOptions.TopLeft;
             label.fontSize = LedgeUITokens.BodySize;
             label.font = LedgeUITokens.UIFont;
-            label.enableWordWrapping = true;
+            label.textWrappingMode = TextWrappingModes.Normal;
             label.color = LedgeUITokens.InkFaint;
             label.raycastTarget = false;
             label.enableAutoSizing = false;


### PR DESCRIPTION
**Summary**
- adds the `BOARD VIEW` eyebrow to the top-right BoardViewHud panel and gives the panel enough height for the label, toggle, and comparison row
- preserves the comparison row width behavior with `childControlWidth = true`
- replaces deprecated `StatusLog` `enableWordWrapping` usage with `textWrappingMode = TextWrappingModes.Normal`

**Verification**
- `git diff --check`
- Unity MCP via `unity-ledgeboardgame`: correct `Application.dataPath` binding
- Unity console after runtime verification: 0 errors / 0 warnings
- Confirmed no `StatusLog.cs` / `enableWordWrapping` / `CS0618` warning remains
- Runtime 2-seat landscape BoardViewHud metrics + screenshot verified
- Runtime 6-seat landscape BoardViewHud metrics + screenshot verified
- Codex final closure review: approve, no blockers

**Notes**
- Gemini/agy review was explicitly waived by Lake for this low-risk slice.
- Portrait/narrow viewport was not verified; Codex accepted it as an optional follow-up, not a CP056 merge blocker.
- Untracked local `kit-import/` and `kit-import-v6/` directories are intentionally excluded.