### PR TITLE
fix(ledge): untint rim keyline overlay masks

### DIFF
--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/LedgeSpriteFactory.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/LedgeSpriteFactory.cs
@@ -5,8 +5,9 @@ namespace Magi.LedgeBoardGame.Board
 {
     /// Runtime-generated UI sprites so Phase 1 visual polish ships without art-pipeline dependencies.
     /// Shapes are baked into 128x128 RGBA textures with 2x supersample AA. Caller-tintable sprites
-    /// (Disc, Counter, HexFrame, BridgeFrame, WallFrame) are pure white on transparent; colored
-    /// sprites (HexFill/HexSplit/BridgeFill/WallFill) bake pigment in so they can represent
+    /// (Disc, Counter, HexFrame, BridgeFrame, WallFrame, HexSilhouette, BridgeSilhouette,
+    /// WallSilhouette) are pure white on transparent; colored sprites
+    /// (HexFill/HexSplit/BridgeFill/WallFill) bake pigment in so they can represent
     /// multi-color gradients and splits that a UI.Image tint can't reproduce.
     public static class LedgeSpriteFactory
     {
@@ -47,6 +48,16 @@ namespace Magi.LedgeBoardGame.Board
         public static Sprite BridgeFrameGlow => GetOrBuild("bridgeframeglow", BuildBridgeFrameGlow);
         public static Sprite WallFrame => GetOrBuild("wallframe", BuildWallFrame);
         public static Sprite WallFrameGlow => GetOrBuild("wallframeglow", BuildWallFrameGlow);
+
+        // Full-shape silhouette masks (tintable white-on-transparent). Same alpha geometry as the
+        // matching *Fill sprites, but with no pigment baked into RGB, so a UI.Image tint reproduces
+        // the requested color exactly. The rim/keyline underlays (SpaceView's visitor + movable-
+        // source bands) must use these rather than the tile's fill sprite: on a split/gradient fill
+        // the baked pigment multiplies into the tint, which is what made CP067's gold rim read as
+        // an arc on the token side instead of a uniform band.
+        public static Sprite HexSilhouette => GetOrBuild("hexsilhouette", BuildHexSilhouette);
+        public static Sprite BridgeSilhouette => GetOrBuild("bridgesilhouette", BuildBridgeSilhouette);
+        public static Sprite WallSilhouette => GetOrBuild("wallsilhouette", BuildWallSilhouette);
 
         public static Sprite GetHexFill(Color color)
         {
@@ -227,6 +238,25 @@ namespace Magi.LedgeBoardGame.Board
             return Finalize(px, "HexFrameGlow");
         }
 
+        /// White-on-transparent twin of BuildHexFill — identical R/apothem so the mask covers
+        /// exactly the same footprint as any hex fill (solid, split, or Ring3-off split).
+        private static Sprite BuildHexSilhouette()
+        {
+            var px = new Color32[Size * Size];
+            float cx = (Size - 1) * 0.5f;
+            float R = (Size * 0.5f - 0.5f) * HexRadiusFraction;
+            float apothem = R * Mathf.Sqrt(3f) * 0.5f;
+            for (int y = 0; y < Size; y++)
+            {
+                for (int x = 0; x < Size; x++)
+                {
+                    float a = SampleAA(x, y, cx, (xs, ys) => HexAlpha(xs, ys, apothem));
+                    px[y * Size + x] = new Color32(255, 255, 255, (byte)(a * 255f));
+                }
+            }
+            return Finalize(px, "HexSilhouette");
+        }
+
         // ---------------- Builders: Bridge ----------------
 
         // Bridge silhouette is a 12-vertex polygon symmetric about the radial (+Y) axis,
@@ -378,6 +408,23 @@ namespace Magi.LedgeBoardGame.Board
             return Finalize(px, "BridgeFrameGlow");
         }
 
+        /// White-on-transparent twin of BuildBridgeFill — same 12-gon alpha, no baked gradient.
+        private static Sprite BuildBridgeSilhouette()
+        {
+            var px = new Color32[Size * Size];
+            float cx = (Size - 1) * 0.5f;
+            float halfSize = cx;
+            for (int y = 0; y < Size; y++)
+            {
+                for (int x = 0; x < Size; x++)
+                {
+                    float a = SampleAA(x, y, cx, (xs, ys) => BridgeAlpha(xs, ys, halfSize));
+                    px[y * Size + x] = new Color32(255, 255, 255, (byte)(a * 255f));
+                }
+            }
+            return Finalize(px, "BridgeSilhouette");
+        }
+
         // ---------------- Builders: Wall ----------------
 
         // Wall silhouette is a 6-vertex polygon symmetric about the radial (+Y) axis,
@@ -485,6 +532,28 @@ namespace Magi.LedgeBoardGame.Board
                 }
             }
             return Finalize(px, "WallFrameGlow");
+        }
+
+        /// White-on-transparent twin of BuildWallFill — same 6-gon alpha, no baked gray.
+        private static Sprite BuildWallSilhouette()
+        {
+            var px = new Color32[Size * Size];
+            float cx = (Size - 1) * 0.5f;
+            float halfSize = cx;
+            for (int y = 0; y < Size; y++)
+            {
+                for (int x = 0; x < Size; x++)
+                {
+                    float a = SampleAA(x, y, cx, (xs, ys) =>
+                    {
+                        float nx = xs / halfSize;
+                        float ny = ys / halfSize;
+                        return WallInside(nx, ny);
+                    });
+                    px[y * Size + x] = new Color32(255, 255, 255, (byte)(a * 255f));
+                }
+            }
+            return Finalize(px, "WallSilhouette");
         }
 
         // ---------------- Legacy builders (Disc / Ring / Counter / FrameGlow) ----------------

--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/SpaceView.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/SpaceView.cs
@@ -600,12 +600,15 @@ namespace Magi.LedgeBoardGame.Board
             if (_sourceKeylineImage != null) _sourceKeylineImage.transform.SetSiblingIndex(idx++);
         }
 
-        // Reuses fillImage's own sprite so the overlay always matches the
-        // tile's real silhouette — hex, bespoke bridge 12-gon, or bespoke wall
-        // hexagon — with no per-shape special-casing. Uniform scale only (no
-        // independent x/y, no position offset): any asymmetry breaks the
-        // constant-band illusion on the bespoke polys. Shared by the visitor
-        // rim (CP064) and the movable-source rim (CP067).
+        // Uses the untinted white silhouette mask for the tile's shape (CP068)
+        // so the overlay matches the tile's real outline — hex, bespoke bridge
+        // 12-gon, or bespoke wall hexagon — while letting the Image tint set
+        // the band's color exactly. The mask is picked in ApplyShapeAndFill;
+        // see _silhouetteSprite for why the tile's own fill sprite is no longer
+        // reused here. Uniform scale only (no independent x/y, no position
+        // offset): any asymmetry breaks the constant-band illusion on the
+        // bespoke polys. Shared by the visitor rim (CP064) and the movable-
+        // source rim (CP067).
         private Image CreateSilhouetteChild(string name)
         {
             var go = new GameObject(name, typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
@@ -617,7 +620,7 @@ namespace Magi.LedgeBoardGame.Board
             rt.anchoredPosition = Vector2.zero;
 
             var img = go.GetComponent<Image>();
-            img.sprite = fillImage.sprite;
+            img.sprite = CurrentSilhouetteSprite;
             img.raycastTarget = false;
             img.color = new Color(0f, 0f, 0f, 0f);
             go.SetActive(false);
@@ -633,10 +636,26 @@ namespace Magi.LedgeBoardGame.Board
             rt.localRotation = fillImage.transform.localRotation;
         }
 
-        /// Called after ApplyShapeAndFill assigns a (possibly new) fillImage
-        /// sprite/rotation so the underlay layers stay in sync with the tile's
-        /// current shape instead of freezing on whatever shape was active when
-        /// they were first created (pooled/reused SpaceViews).
+        // Untinted white mask matching this tile's shape, chosen alongside the
+        // fill/frame/glow sprites in ApplyShapeAndFill. The underlays used to
+        // copy fillImage.sprite, which is shape-correct but carries baked
+        // pigment (Ring2 splits, bridge gradients); UI tint multiplies against
+        // that pigment, so the accent rim picked up the fill's hue unevenly —
+        // Design saw CP067's gold rim read as an arc on the token side rather
+        // than a uniform band. A white mask multiplies to exactly the tint.
+        private Sprite _silhouetteSprite;
+
+        // Falls back to the fill sprite only if a layer is somehow created
+        // before the first ApplyShapeAndFill; RefreshSilhouetteLayers corrects
+        // it on the next SetData either way.
+        private Sprite CurrentSilhouetteSprite =>
+            _silhouetteSprite != null ? _silhouetteSprite
+            : (fillImage != null ? fillImage.sprite : null);
+
+        /// Called after ApplyShapeAndFill assigns a (possibly new) shape mask /
+        /// fillImage rotation so the underlay layers stay in sync with the
+        /// tile's current shape instead of freezing on whatever shape was
+        /// active when they were first created (pooled/reused SpaceViews).
         private void RefreshSilhouetteLayers()
         {
             if (fillImage == null) return;
@@ -655,7 +674,7 @@ namespace Magi.LedgeBoardGame.Board
         private void RefreshSilhouetteLayer(Image layer)
         {
             if (layer == null) return;
-            layer.sprite = fillImage.sprite;
+            layer.sprite = CurrentSilhouetteSprite;
             ApplySilhouetteTransform(layer.rectTransform);
         }
 
@@ -1128,15 +1147,18 @@ namespace Magi.LedgeBoardGame.Board
             }
         }
 
-        /// Shape + color dispatch. Called once per SetData. Assigns sprites for fill/frame/glow,
-        /// picks the right color rule per space type, and rotates non-hex shapes to align with
-        /// their wedge axis.
+        /// Shape + color dispatch. Called once per SetData. Assigns sprites for fill/frame/glow
+        /// plus the untinted silhouette mask the rim/keyline underlays draw with, picks the right
+        /// color rule per space type, and rotates non-hex shapes to align with their wedge axis.
         private void ApplyShapeAndFill(int id, SpaceMeta meta)
         {
             float rotZ = 0f;
             Sprite fillSprite;
             Sprite frameSprite;
             Sprite glowSprite;
+            // Center/Ring2/Ring3/OuterAdded/default all draw on the hex outline; only the two
+            // bespoke inner-ring polys override this below.
+            Sprite silhouetteSprite = LedgeSpriteFactory.HexSilhouette;
 
             switch (meta.Type)
             {
@@ -1154,6 +1176,7 @@ namespace Magi.LedgeBoardGame.Board
                     fillSprite = LedgeSpriteFactory.GetBridgeFill(outerColor: complementColor, innerColor: ownColor);
                     frameSprite = LedgeSpriteFactory.BridgeFrame;
                     glowSprite = LedgeSpriteFactory.BridgeFrameGlow;
+                    silhouetteSprite = LedgeSpriteFactory.BridgeSilhouette;
                     break;
                 }
 
@@ -1164,6 +1187,7 @@ namespace Magi.LedgeBoardGame.Board
                     fillSprite = LedgeSpriteFactory.GetWallFill();
                     frameSprite = LedgeSpriteFactory.WallFrame;
                     glowSprite = LedgeSpriteFactory.WallFrameGlow;
+                    silhouetteSprite = LedgeSpriteFactory.WallSilhouette;
                     break;
                 }
 
@@ -1249,6 +1273,7 @@ namespace Magi.LedgeBoardGame.Board
                 frameGlowImage.transform.localRotation = Quaternion.Euler(0f, 0f, rotZ);
             }
 
+            _silhouetteSprite = silhouetteSprite;
             RefreshSilhouetteLayers();
         }
 


### PR DESCRIPTION
## Summary
- Add white-on-transparent silhouette mask sprites for hex, wall, and bridge tile overlays.
- Route visitor and movable-source rim/keyline underlays through those untinted masks instead of pigmented fill sprites.
- Preserve existing fill/frame/glow sprites and existing source-over-visitor draw ordering.

## Visual evidence
- Real Unity Play Mode capture covered natural center source, injected Ring2 source, Ring2 visitor, wall visitor, bridge visitor, and bridge source+visitor overlap.
- Layer logs confirmed per-shape masks with `center=#FFFFFFFF edge=#FFFFFF00` and uniform overlay tint colors.
- Claude Design verdict: `approve_with_notes`, no visual blockers. Focus question passed: rim/keyline bands now read as uniform external bands rather than face tint/wash.

## Reviews
- Claude source resolution: ready for Design review.
- Codex: approve_with_notes, no blockers.
- Gemini/agy: approve, no blockers.
- Claude Design: approve_with_notes, no visual blockers.

## Testing
- Unity relay compile/import/status check passed before commit: not playing, not compiling/updating, `scriptCompilationFailed=False`, scene not dirty.
- `git diff --check` passed.
- `dotnet build LedgeBoardGame/LedgeBoardGame.sln` was attempted but is blocked by local Unity/VS tooling references, notably missing `Microsoft.Unity.Analyzers.dll` under Visual Studio Tools for Unity plus unresolved Unity/Plastic assemblies in `Magi.UnityTools.csproj`; this is documented as an environment/tooling caveat, not a Unity import failure.

## Follow-ups intentionally not in this branch
- Portrait capture of the highlight/visitor family.
- StatusLog-over-nameplate overlap in the lower-left.
- Caps-label contrast set.
- Upright vs italic headline decision from CP066.
- Minor ledger note: interior packed tiles show partial-edge bands by design; revisit thickness/alpha only if playtests show missed source/visitor cues.
