### PR TITLE
fix(ledge): raise visitor rim alpha floor

### DIFF
--- a/LedgeBoardGame/Assets/_Project/Prefabs/SpaceView.prefab
+++ b/LedgeBoardGame/Assets/_Project/Prefabs/SpaceView.prefab
@@ -183,9 +183,28 @@ MonoBehaviour:
   pulseFrequencyHz: 1.4
   pulseMinAlpha: 0.25
   pulseMaxAlpha: 0.85
+  innerRingPulseDamping: 0.5
+  radialPhasePerHop: 0.15
+  validTargetFadeInDelay: 0.6
+  validTargetFadeDuration: 0.35
   sourceBreatheHz: 0.7
   sourceMinAlpha: 0
   sourceMaxAlpha: 0.08
+  sourceKeylineScale: 1.06
+  sourceRimScale: 1.16
+  sourceRimAlphaMin: 0.85
+  sourceRimAlphaMax: 1
+  sourceRimPulsePeriodSeconds: 1.6
+  sourceKeylineAlpha: 0.95
+  visitorKeylineScale: 1.045
+  visitorRimScale: 1.115
+  visitorWaveEndScale: 1.55
+  visitorWaveDuration: 0.3
+  visitorRimAlphaMin: 0.85
+  visitorRimAlphaMax: 1
+  visitorRimPulsePeriodSeconds: 2.4
+  visitorKeylineAlpha: 0.95
+  visitorWaveStartAlpha: 0.95
   onClicked:
     m_PersistentCalls:
       m_Calls: []

--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/SpaceView.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/SpaceView.cs
@@ -104,8 +104,17 @@ namespace Magi.LedgeBoardGame.Board
         [SerializeField] private float visitorRimScale = 1.115f;
         [SerializeField] private float visitorWaveEndScale = 1.55f;
         [SerializeField] private float visitorWaveDuration = 0.30f;
-        [SerializeField] private float visitorRimAlphaMin = 0.55f;
-        [SerializeField] private float visitorRimAlphaMax = 0.85f;
+        // CP072: raised from 0.55/0.85 to the source rim's envelope. CP071's portrait
+        // captures caught the gap — at 720x1280 this tile renders ~49px wide instead of
+        // landscape's ~120px, so the same alpha has roughly a third of the pixels to
+        // carry the band, and Claude Design could not locate the rim at 0.550 at all
+        // (the visitor pill was carrying the entire visitor signal on a phone). The
+        // 0.55 floor dates to CP054's diffuse glow, which needed a deep trough to feel
+        // calm; the CP064 crisp-rim primitive does not. Kept equal to
+        // sourceRimAlphaMin/Max so the two rim families can't drift apart again —
+        // SpaceViewRimAlphaContractTests asserts the parity rather than the literals.
+        [SerializeField] private float visitorRimAlphaMin = 0.85f;
+        [SerializeField] private float visitorRimAlphaMax = 1.0f;
         [SerializeField] private float visitorRimPulsePeriodSeconds = 2.4f;
         [SerializeField] private float visitorKeylineAlpha = 0.95f;
         [SerializeField] private float visitorWaveStartAlpha = 0.95f;

--- a/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/SpaceViewRimAlphaContractTests.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/SpaceViewRimAlphaContractTests.cs
@@ -1,0 +1,158 @@
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using Magi.LedgeBoardGame.Board;
+
+namespace Magi.LedgeBoardGame.Tests.EditMode
+{
+    /// CP072: the visitor rim and the movable-source rim must breathe over the
+    /// same alpha envelope.
+    ///
+    /// CP071's portrait captures caught the regression these tests lock down.
+    /// The visitor rim's floor of 0.55 was tuned at CP054, when tiles rendered
+    /// ~120px wide in landscape and the primitive was still a diffuse glow that
+    /// needed a deep trough to feel calm. At 720x1280 the same tile is ~49px, so
+    /// the visible band is roughly a third of the pixels at the same alpha, and
+    /// Claude Design could not locate the rim at all at 0.550 — the visitor pill
+    /// was carrying the entire visitor signal on a phone. The source rim, floored
+    /// at 0.85 by CP067, stayed findable in the same frames at the same tile size.
+    ///
+    /// Asserted against the source rim's constants rather than hard-coded numbers
+    /// so the two families cannot silently drift apart again: retuning the source
+    /// rim alone breaks this test rather than quietly reintroducing the gap.
+    [TestFixture]
+    public class SpaceViewRimAlphaContractTests
+    {
+        // Design's stated requirement from the CP071 verdict ("raise the visitor
+        // rim alpha floor to ~0.80-0.85 in line with the source rim"). Kept as an
+        // absolute lower bound alongside the parity checks so the contract still
+        // fails if someone lowers BOTH families together.
+        private const float DesignMinimumRimFloor = 0.80f;
+        private const float Tolerance = 0.0001f;
+
+        private GameObject _go;
+        private SpaceView _view;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _go = new GameObject("SpaceViewUnderTest", typeof(RectTransform));
+            _view = _go.AddComponent<SpaceView>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_go != null) Object.DestroyImmediate(_go);
+        }
+
+        [Test]
+        public void VisitorRimFloor_MatchesSourceRimFloor()
+        {
+            float visitorMin = GetFloatField("visitorRimAlphaMin");
+            float sourceMin = GetFloatField("sourceRimAlphaMin");
+
+            Assert.That(visitorMin, Is.EqualTo(sourceMin).Within(Tolerance),
+                "Visitor and source rims must share an alpha floor so neither family " +
+                "becomes unfindable at portrait tile sizes (CP071/CP072).");
+        }
+
+        [Test]
+        public void VisitorRimPeak_MatchesSourceRimPeak()
+        {
+            float visitorMax = GetFloatField("visitorRimAlphaMax");
+            float sourceMax = GetFloatField("sourceRimAlphaMax");
+
+            Assert.That(visitorMax, Is.EqualTo(sourceMax).Within(Tolerance),
+                "Visitor and source rims must share an alpha peak (CP072: breathe 0.85 -> 1.0).");
+        }
+
+        [Test]
+        public void VisitorRimFloor_MeetsDesignMinimum()
+        {
+            float visitorMin = GetFloatField("visitorRimAlphaMin");
+
+            Assert.That(visitorMin, Is.GreaterThanOrEqualTo(DesignMinimumRimFloor),
+                "CP071 Design verdict: the visitor rim is not findable in portrait below ~0.80.");
+        }
+
+        [Test]
+        public void VisitorRimEnvelope_IsAscendingAndWithinUnitRange()
+        {
+            float visitorMin = GetFloatField("visitorRimAlphaMin");
+            float visitorMax = GetFloatField("visitorRimAlphaMax");
+
+            Assert.That(visitorMin, Is.LessThanOrEqualTo(visitorMax), "Floor must not exceed peak.");
+            Assert.That(visitorMax, Is.LessThanOrEqualTo(1f), "Alpha cannot exceed 1.");
+        }
+
+        /// Exercises the real breathe rather than only the serialized constants.
+        /// ComputeSteadyRimAlpha samples Time.unscaledTime, so the phase is
+        /// arbitrary in EditMode and the exact value is not assertable — but the
+        /// result must land inside the envelope whatever the phase, which is the
+        /// property that actually reaches the screen.
+        [Test]
+        public void ComputeSteadyRimAlpha_StaysWithinTheAssertedEnvelope()
+        {
+            float visitorMin = GetFloatField("visitorRimAlphaMin");
+            float visitorMax = GetFloatField("visitorRimAlphaMax");
+
+            var method = typeof(SpaceView).GetMethod("ComputeSteadyRimAlpha",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(method, Is.Not.Null, "ComputeSteadyRimAlpha not found — did the breathe move?");
+
+            float alpha = (float)method.Invoke(_view, null);
+
+            Assert.That(alpha, Is.GreaterThanOrEqualTo(visitorMin - Tolerance));
+            Assert.That(alpha, Is.LessThanOrEqualTo(visitorMax + Tolerance));
+            Assert.That(alpha, Is.GreaterThanOrEqualTo(DesignMinimumRimFloor - Tolerance),
+                "Every phase of the visitor breathe must stay above the portrait findability floor.");
+        }
+
+        /// The tests above construct a SpaceView directly, which reads the C# field
+        /// initializers. Runtime does not: BoardPresenter.CreateSpaceView instantiates
+        /// spaceViewPrefab when it is assigned, and it is — Main.unity wires
+        /// GameController.boardPresenterPrefab to BoardPresenter.prefab, whose
+        /// spaceViewPrefab points at SpaceView.prefab. Serialized values on that asset
+        /// therefore win over the initializers for any field the asset carries, which is
+        /// how pulseFrequencyHz currently ships at 1.4 while the source default says 0.9.
+        /// CP072's runtime capture measured the visitor rim at 0.612 and 0.792 — both
+        /// inside the old [0.55, 0.85] envelope — so this asserts the envelope on the
+        /// asset the game actually instantiates, not just on a fresh component.
+        [Test]
+        public void PrefabSerializedVisitorRim_MatchesSourceRimEnvelope()
+        {
+            const string prefabPath = "Assets/_Project/Prefabs/SpaceView.prefab";
+            var prefab = UnityEditor.AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath);
+            Assert.That(prefab, Is.Not.Null, $"{prefabPath} not found — did the prefab move?");
+
+            var prefabView = prefab.GetComponent<SpaceView>();
+            Assert.That(prefabView, Is.Not.Null, $"{prefabPath} has no SpaceView component.");
+
+            float visitorMin = GetFloatFieldOn(prefabView, "visitorRimAlphaMin");
+            float visitorMax = GetFloatFieldOn(prefabView, "visitorRimAlphaMax");
+            float sourceMin = GetFloatFieldOn(prefabView, "sourceRimAlphaMin");
+            float sourceMax = GetFloatFieldOn(prefabView, "sourceRimAlphaMax");
+
+            Assert.That(visitorMin, Is.EqualTo(sourceMin).Within(Tolerance),
+                "Prefab visitor rim floor must match the source rim floor — this is the " +
+                "instance Play Mode actually spawns.");
+            Assert.That(visitorMax, Is.EqualTo(sourceMax).Within(Tolerance),
+                "Prefab visitor rim peak must match the source rim peak.");
+            Assert.That(visitorMin, Is.GreaterThanOrEqualTo(DesignMinimumRimFloor),
+                "CP071 Design verdict: below ~0.80 the visitor rim is unfindable in portrait.");
+        }
+
+        private float GetFloatField(string name)
+        {
+            return GetFloatFieldOn(_view, name);
+        }
+
+        private static float GetFloatFieldOn(SpaceView target, string name)
+        {
+            var field = typeof(SpaceView).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null, $"SpaceView.{name} not found — was the field renamed?");
+            return (float)field.GetValue(target);
+        }
+    }
+}

--- a/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/SpaceViewRimAlphaContractTests.cs.meta
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/SpaceViewRimAlphaContractTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5240c683628755f49aec1411e0c497ca


### PR DESCRIPTION
## Summary

- Raise the cyan **VisitorRim** alpha envelope to match SourceRim: floor `0.85`, peak `1.0` (was `0.55`/`0.85`).
- Patch the serialized values in `SpaceView.prefab` as well — Unity prefab serialized fields override C# field initializers in Play Mode, so the code change alone would not take effect at runtime.
- Add EditMode contract tests (`SpaceViewRimAlphaContractTests`) covering both the fresh-component defaults and the `SpaceView.prefab` serialized runtime path. The tests assert **parity with the source rim envelope** rather than the literal values, so the two rim families can't silently drift apart again.

Motivation: at portrait 720x1280 a space tile renders ~49px wide vs ~120px in landscape, so the old `0.55` floor had roughly a third of the pixels to carry the band and the visitor rim was not findable — the visitor pill was carrying the entire visitor signal on phones.

## Test plan

- **Focused live Unity EditMode run: 6/6 passed** — `LedgeBoardGame/Logs/cp072-green-results-live.xml`. Includes the prefab-path regression test `PrefabSerializedVisitorRim_MatchesSourceRimEnvelope`.
- **Real Unity Play Mode runtime capture** (after the prefab fix):
  - Portrait 720x1280 live VisitorRim alpha: `0.851`
  - Landscape 1920x1080 live VisitorRim alpha: `0.852`
- Design handoff uploaded and verified at `handoff/cp072-visitor-rim-alpha-floor-2026-09-01/`.

### Review verdicts

| Reviewer | Verdict | Blockers |
| --- | --- | --- |
| Codex | `approve_with_notes` | none |
| Gemini/agy | `approve` | none |
| Claude Design | `approve` (VisitorRim findability: **pass**) | none |

## Notes

- The unrelated untracked directories `kit-import/` and `kit-import-v6/` remain untracked and were **not** staged or committed. Only the four intended source paths are in this PR.
- No remaining CP072 blockers. Nonblocking design-ledger items are carry-forward only: portrait toast-over-panel overlap, portrait BOARD VIEW micro-type/caps-label contrast, CP066 italic-headline decision, 2-seat portrait dead-space composition, pan/zoom overlap clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
