### PR TITLE
fix(ledge): keep portrait toast clear of top chrome

### DIFF
--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardViewHud.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardViewHud.cs
@@ -12,10 +12,23 @@ namespace Magi.LedgeBoardGame.Board
     /// re-save.
     public class BoardViewHud : MonoBehaviour
     {
+        /// Panel footprint, in canvas reference units. Public because the
+        /// top-band chrome has to be placed around it — see
+        /// StatusBanner.ResolveToastAnchoredPosition.
+        public const float HudWidth = 280f;
+        public const float HudHeight = 144f;
+
         private MultiBoardLayout _layout;
         private LedgeButton _toggleButton;
         private RectTransform _comparisonGroup;
         private TextMeshProUGUI _opponentLabel;
+        private RectTransform _root;
+
+        /// The top-right glass panel this component builds under the canvas. Note
+        /// this is NOT the component's own transform: BoardViewHud lives on a
+        /// bare host GameObject and builds its UI as a canvas sibling. Null until
+        /// Initialize has run.
+        public RectTransform Root => _root;
 
         public void Initialize(MultiBoardLayout layout)
         {
@@ -72,8 +85,9 @@ namespace Magi.LedgeBoardGame.Board
             rootRect.anchorMax = new Vector2(1f, 1f);
             rootRect.pivot = new Vector2(1f, 1f);
             rootRect.anchoredPosition = new Vector2(-LedgeUITokens.PanelEdgeInset, -LedgeUITokens.PanelEdgeInset);
-            rootRect.sizeDelta = new Vector2(280f, 144f);
+            rootRect.sizeDelta = new Vector2(HudWidth, HudHeight);
             rootRect.SetAsLastSibling();
+            _root = rootRect;
 
             // Glass panel backdrop so this matches the TL/BL chrome.
             var glass = LedgeGlassPanel.Build(rootRect, "Glass");

--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/StatusBanner.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/StatusBanner.cs
@@ -7,10 +7,13 @@ using UnityEngine.UI;
 
 namespace Magi.LedgeBoardGame.Board
 {
-    /// Bottom-anchored narration strip that fades in, holds, and fades out. Used to
+    /// Centered narration toast that fades in, holds, and fades out. Used to
     /// announce both player-driven transitions ("Player 1 ended turn") and state-based
     /// effects ("Player 2 eliminated"). Messages queue serially so a burst of events
     /// reads in the order they occurred instead of overwriting each other.
+    ///
+    /// Its vertical slot is resolved from canvas geometry rather than fixed —
+    /// see ResolveToastAnchoredPosition.
     [RequireComponent(typeof(RectTransform))]
     [RequireComponent(typeof(CanvasGroup))]
     public class StatusBanner : MonoBehaviour
@@ -21,9 +24,26 @@ namespace Magi.LedgeBoardGame.Board
         [SerializeField] private float holdDuration = 2.0f;
         [SerializeField] private float fadeOutDuration = 0.5f;
 
+        /// The toast's footprint. Public so the layout contract can reason about
+        /// the rect the toast will occupy without standing up a canvas.
+        public const float ToastWidth = 560f;
+        public const float ToastHeight = 72f;
+
         private CanvasGroup _canvasGroup;
         private readonly Queue<string> _pending = new Queue<string>();
         private bool _playing;
+
+        // Responsive refs (see ApplyResponsiveLayout). The two top-corner chrome
+        // panels are what the toast has to share the top band with.
+        private RectTransform _selfRect;
+        private RectTransform _canvasRect;
+        private LedgeYouPanel _youPanel;
+        private BoardViewHud _viewHud;
+        private float _lastCanvasWidth = -1f;
+        private float _lastLeftWidth = -1f;
+        private float _lastLeftHeight = -1f;
+        private float _lastRightWidth = -1f;
+        private float _lastRightHeight = -1f;
 
         private void Awake()
         {
@@ -37,14 +57,17 @@ namespace Magi.LedgeBoardGame.Board
         private void EnsureVisuals()
         {
             var selfRect = (RectTransform)transform;
+            _selfRect = selfRect;
             // Top-center transient toast. Slides down (well, fades in) for
-            // dramatic moments ("Player 2 eliminated") without competing with
-            // the persistent TL "You" panel or the TR view toggle.
+            // dramatic moments ("Player 2 eliminated"). The y offset is not a
+            // constant: on narrow canvases the top band is already spoken for by
+            // the TL "You" panel and the TR view toggle, so ApplyResponsiveLayout
+            // drops the toast clear of them. See ResolveToastAnchoredPosition.
             selfRect.anchorMin = new Vector2(0.5f, 1f);
             selfRect.anchorMax = new Vector2(0.5f, 1f);
             selfRect.pivot = new Vector2(0.5f, 1f);
             selfRect.anchoredPosition = new Vector2(0f, -LedgeUITokens.PanelEdgeInset);
-            selfRect.sizeDelta = new Vector2(560f, 72f);
+            selfRect.sizeDelta = new Vector2(ToastWidth, ToastHeight);
 
             if (background == null)
             {
@@ -82,6 +105,139 @@ namespace Magi.LedgeBoardGame.Board
                 label.color = LedgeUITokens.Ink;
                 label.raycastTarget = false;
             }
+
+            ApplyResponsiveLayout();
+        }
+
+        // ── Responsive placement ─────────────────────────────────────────
+        // CP073. The toast used to sit at a fixed top-center inset, which is
+        // clear of the corner chrome at the 1920-unit reference width but not on
+        // a phone: a 720x1280 screen scales (reference 1920x1080, match 0.5) to
+        // roughly 1080 canvas units, where the centered 560-wide toast spans
+        // 260..820 and lands on both the 360-wide You panel (28..388) and the
+        // 280-wide Board View HUD (772..1052) at the same top inset. Design read
+        // it as the toast's translucent box sitting over the "Place Light"
+        // headline and the TURN 1 eyebrow.
+        //
+        // Fix moves the toast, not the panels: the You panel is persistent and
+        // load-bearing (it is the "what do I do now" surface), while the toast is
+        // transient, so the transient thing yields.
+
+        /// Where the toast sits, given the canvas width and the measured
+        /// footprints of the two top-corner chrome panels (TL You panel, TR Board
+        /// View HUD). Pass a width of 0 for a corner panel that is absent.
+        ///
+        /// Wide layouts keep the accepted top-center inset placement. When the
+        /// centered toast cannot clear a corner panel by a PanelGap, it drops
+        /// below the deeper of the panels it collides with, again one PanelGap
+        /// clear — so the toast stays centered and styled exactly as before and
+        /// only its vertical slot changes.
+        ///
+        /// The breakpoint is geometry, not a resolution string: it falls out of
+        /// PanelEdgeInset/PanelGap, ToastWidth and the measured panel sizes, so
+        /// retuning a token or resizing a panel moves the breakpoint with it.
+        /// (At today's numbers the You panel binds first, at ~1364 canvas units.)
+        public static Vector2 ResolveToastAnchoredPosition(
+            float canvasWidth,
+            float topLeftWidth, float topLeftHeight,
+            float topRightWidth, float topRightHeight)
+        {
+            const float inset = LedgeUITokens.PanelEdgeInset;
+            const float gap = LedgeUITokens.PanelGap;
+            var topCenter = new Vector2(0f, -inset);
+            if (canvasWidth <= 0f) return topCenter;
+
+            float half = canvasWidth * 0.5f;
+            float toastLeft = half - ToastWidth * 0.5f;
+            float toastRight = half + ToastWidth * 0.5f;
+
+            // Depth of the top band the toast actually runs into. Only the panels
+            // it overlaps horizontally count, so a canvas wide enough for one
+            // corner but not the other clears just what it has to.
+            float clearance = 0f;
+            if (topLeftWidth > 0f && toastLeft < inset + topLeftWidth + gap)
+                clearance = Mathf.Max(clearance, topLeftHeight);
+            if (topRightWidth > 0f && toastRight > canvasWidth - inset - topRightWidth - gap)
+                clearance = Mathf.Max(clearance, topRightHeight);
+
+            if (clearance <= 0f) return topCenter;
+            return new Vector2(0f, -(inset + clearance + gap));
+        }
+
+        // Re-fit when the canvas resizes (window resize / device rotation) or a
+        // corner panel changes footprint (the You panel's compact toggle). A few
+        // rect reads a frame, with an early-out on unchanged geometry.
+        private void Update()
+        {
+            ResolveChromeRefs();
+            if (_canvasRect == null || _selfRect == null) return;
+
+            float canvasWidth = _canvasRect.rect.width;
+            Measure(YouPanelRect, out float lw, out float lh);
+            Measure(ViewHudRect, out float rw, out float rh);
+            if (Mathf.Approximately(canvasWidth, _lastCanvasWidth)
+                && Mathf.Approximately(lw, _lastLeftWidth)
+                && Mathf.Approximately(lh, _lastLeftHeight)
+                && Mathf.Approximately(rw, _lastRightWidth)
+                && Mathf.Approximately(rh, _lastRightHeight)) return;
+
+            ApplyLayout(canvasWidth, lw, lh, rw, rh);
+        }
+
+        private void ApplyResponsiveLayout()
+        {
+            ResolveChromeRefs();
+            if (_selfRect == null) return;
+            float canvasWidth = _canvasRect != null ? _canvasRect.rect.width : 0f;
+            Measure(YouPanelRect, out float lw, out float lh);
+            Measure(ViewHudRect, out float rw, out float rh);
+            ApplyLayout(canvasWidth, lw, lh, rw, rh);
+        }
+
+        private void ApplyLayout(float canvasWidth, float lw, float lh, float rw, float rh)
+        {
+            _lastCanvasWidth = canvasWidth;
+            _lastLeftWidth = lw;
+            _lastLeftHeight = lh;
+            _lastRightWidth = rw;
+            _lastRightHeight = rh;
+            _selfRect.anchoredPosition =
+                ResolveToastAnchoredPosition(canvasWidth, lw, lh, rw, rh);
+        }
+
+        // The TR Board View HUD is built after the banner (GameController runs
+        // EnsureStatusBanner well before EnsureBoardViewHud), so refs resolve
+        // lazily and keep being retried until found rather than cached at Awake.
+        private void ResolveChromeRefs()
+        {
+            if (_selfRect == null) _selfRect = transform as RectTransform;
+            if (_canvasRect == null)
+            {
+                var canvas = GetComponentInParent<Canvas>();
+                if (canvas != null) _canvasRect = canvas.transform as RectTransform;
+            }
+            if (_canvasRect == null) return;
+            if (_youPanel == null) _youPanel = _canvasRect.GetComponentInChildren<LedgeYouPanel>(true);
+            if (_viewHud == null) _viewHud = _canvasRect.GetComponentInChildren<BoardViewHud>(true);
+        }
+
+        private RectTransform YouPanelRect =>
+            _youPanel != null ? _youPanel.transform as RectTransform : null;
+
+        private RectTransform ViewHudRect => _viewHud != null ? _viewHud.Root : null;
+
+        // A hidden panel is not an obstacle, so it measures as absent.
+        private static void Measure(RectTransform rt, out float width, out float height)
+        {
+            if (rt == null || !rt.gameObject.activeInHierarchy)
+            {
+                width = 0f;
+                height = 0f;
+                return;
+            }
+            var r = rt.rect;
+            width = r.width;
+            height = r.height;
         }
 
         /// Append a message to the narration queue. Safe to call repeatedly; each
@@ -99,6 +255,11 @@ namespace Magi.LedgeBoardGame.Board
             while (_pending.Count > 0)
             {
                 var msg = _pending.Dequeue();
+                // Re-fit before fading in rather than only on canvas resize: the
+                // corner chrome can appear or change size (view HUD build, You
+                // panel compact toggle) between toasts, and a toast that is about
+                // to be visible is exactly when the placement has to be right.
+                ApplyResponsiveLayout();
                 label.text = msg;
                 yield return FadeTo(1f, fadeInDuration);
                 yield return new WaitForSecondsRealtime(holdDuration);

--- a/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/StatusBannerLayoutContractTests.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/StatusBannerLayoutContractTests.cs
@@ -1,0 +1,230 @@
+using NUnit.Framework;
+using UnityEngine;
+using Magi.LedgeBoardGame.Board;
+using Magi.LedgeBoardGame.UI;
+
+namespace Magi.LedgeBoardGame.Tests.EditMode
+{
+    /// CP073: the transient top-center toast must not sit on top of the
+    /// persistent top-corner chrome.
+    ///
+    /// CP072's portrait captures caught the defect. The toast's y offset was a
+    /// constant -PanelEdgeInset, which is clear of both corners at the 1920-unit
+    /// reference width but not on a phone: a 720x1280 screen scales (reference
+    /// 1920x1080, match 0.5) to roughly 1080 canvas units, where the centered
+    /// 560-wide toast spans 260..820 and lands on both the 360-wide You panel
+    /// (28..388) and the 280-wide Board View HUD (772..1052) at the same top
+    /// inset. Design read it as the toast's translucent grey box sitting over the
+    /// "Place Light" headline and the TURN 1 eyebrow.
+    ///
+    /// These are geometry tests against StatusBanner.ResolveToastAnchoredPosition
+    /// — the same pure function the runtime layout pass calls with measured rects
+    /// — rather than a built canvas hierarchy. A ScreenSpaceOverlay Canvas forces
+    /// its own RectTransform to the current game-view size, so a scene-based test
+    /// could not pin a 1080-unit-wide canvas deterministically. Panel footprints
+    /// come from the production constants, so resizing a panel retunes these
+    /// expectations instead of silently invalidating them.
+    [TestFixture]
+    public class StatusBannerLayoutContractTests
+    {
+        private const float Inset = LedgeUITokens.PanelEdgeInset;
+        private const float Gap = LedgeUITokens.PanelGap;
+        private const float Tolerance = 0.01f;
+
+        // Canvas widths in reference units, not screen pixels — see the class
+        // doc for the 720x1280 -> ~1080 derivation.
+        private const float PortraitCanvasWidth = 1080f;
+        private const float LandscapeCanvasWidth = 1920f;
+
+        // Width at which the centered toast's left edge just clears the You
+        // panel's right edge by a PanelGap. Derived, not measured: this is the
+        // breakpoint the production code computes, so nothing here hard-codes a
+        // resolution.
+        private static float YouPanelClearanceWidth =>
+            2f * (Inset + LedgeYouPanel.PanelWidth + Gap + StatusBanner.ToastWidth * 0.5f);
+
+        private static float ViewHudClearanceWidth =>
+            2f * (Inset + BoardViewHud.HudWidth + Gap + StatusBanner.ToastWidth * 0.5f);
+
+        // ── The defect, locked in ────────────────────────────────────────
+
+        /// Guards the premise. If a future layout change makes the old fixed
+        /// top-center inset legal in portrait, the rest of this fixture is
+        /// asserting a constraint that no longer exists and should be revisited.
+        [Test]
+        public void Portrait_OriginalFixedTopInset_WouldCoverTheYouPanel()
+        {
+            var oldPlacement = new Vector2(0f, -Inset);
+
+            Assert.That(Toast(PortraitCanvasWidth, oldPlacement).Overlaps(YouPanel()), Is.True,
+                "The CP073 defect: at portrait width the fixed top-center toast overlaps " +
+                "the You panel headline.");
+            Assert.That(Toast(PortraitCanvasWidth, oldPlacement).Overlaps(ViewHud(PortraitCanvasWidth)), Is.True,
+                "It overlaps the top-right Board View HUD in the same frame.");
+        }
+
+        // ── Narrow / portrait ────────────────────────────────────────────
+
+        [Test]
+        public void Portrait_ToastDropsBelowTheTopChrome()
+        {
+            var pos = Resolve(PortraitCanvasWidth, LedgeYouPanel.FullHeight);
+
+            Assert.That(pos.y, Is.LessThan(-Inset),
+                "Portrait must not leave the toast at the shared top inset.");
+            // Both corners are in the way at this width, so the toast clears the
+            // deeper of the two (the 144-tall Board View HUD).
+            float deepest = Mathf.Max(LedgeYouPanel.FullHeight, BoardViewHud.HudHeight);
+            Assert.That(pos.y, Is.EqualTo(-(Inset + deepest + Gap)).Within(Tolerance));
+            Assert.That(pos.y, Is.LessThanOrEqualTo(-(Inset + LedgeYouPanel.FullHeight + Gap) + Tolerance),
+                "At minimum the toast must clear the full-height You panel by a PanelGap.");
+        }
+
+        [Test]
+        public void Portrait_ResolvedToast_ClearsTheYouPanelByAPanelGap()
+        {
+            var toast = Toast(PortraitCanvasWidth, Resolve(PortraitCanvasWidth, LedgeYouPanel.FullHeight));
+            var you = YouPanel();
+
+            Assert.That(toast.Overlaps(you), Is.False, "Toast still overlaps the You panel.");
+            Assert.That(toast.yMin - you.yMax, Is.GreaterThanOrEqualTo(Gap - Tolerance),
+                "Non-overlap is not enough — the toast needs a PanelGap of air below the panel.");
+        }
+
+        [Test]
+        public void Portrait_ResolvedToast_ClearsTheBoardViewHudByAPanelGap()
+        {
+            var toast = Toast(PortraitCanvasWidth, Resolve(PortraitCanvasWidth, LedgeYouPanel.FullHeight));
+            var hud = ViewHud(PortraitCanvasWidth);
+
+            Assert.That(toast.Overlaps(hud), Is.False, "Toast still overlaps the Board View HUD.");
+            Assert.That(toast.yMin - hud.yMax, Is.GreaterThanOrEqualTo(Gap - Tolerance));
+        }
+
+        /// Comparison view at 3+ seats slims the You panel to CompactHeight. The
+        /// toast is placed off the measured rect, so it rides up with it — but
+        /// only as far as the (unchanged) Board View HUD allows.
+        [Test]
+        public void Portrait_CompactYouPanel_StillClearsBothCorners()
+        {
+            var pos = Resolve(PortraitCanvasWidth, LedgeYouPanel.CompactHeight);
+            var toast = Toast(PortraitCanvasWidth, pos);
+
+            Assert.That(toast.Overlaps(YouPanel(LedgeYouPanel.CompactHeight)), Is.False);
+            Assert.That(toast.Overlaps(ViewHud(PortraitCanvasWidth)), Is.False);
+            Assert.That(pos.y, Is.EqualTo(-(Inset + BoardViewHud.HudHeight + Gap)).Within(Tolerance),
+                "With the You panel slimmed, the Board View HUD is the binding obstacle.");
+        }
+
+        // ── Wide / landscape: the accepted placement is preserved ────────
+
+        [Test]
+        public void Landscape_KeepsTheOriginalTopCenterInset()
+        {
+            var pos = Resolve(LandscapeCanvasWidth, LedgeYouPanel.FullHeight);
+
+            Assert.That(pos.x, Is.EqualTo(0f).Within(Tolerance), "The toast stays centered.");
+            Assert.That(pos.y, Is.EqualTo(-Inset).Within(Tolerance),
+                "CP073 must not move the toast on layouts where it never collided.");
+        }
+
+        [Test]
+        public void Landscape_ToastAndCornerChrome_DoNotOverlap()
+        {
+            var toast = Toast(LandscapeCanvasWidth, Resolve(LandscapeCanvasWidth, LedgeYouPanel.FullHeight));
+
+            Assert.That(toast.Overlaps(YouPanel()), Is.False);
+            Assert.That(toast.Overlaps(ViewHud(LandscapeCanvasWidth)), Is.False);
+        }
+
+        // ── Breakpoint is derived from tokens, not a resolution ─────────
+
+        [Test]
+        public void Breakpoint_SitsExactlyWhereTheGeometrySaysItShould()
+        {
+            float atClearance = Resolve(YouPanelClearanceWidth, LedgeYouPanel.FullHeight).y;
+            float justBelow = Resolve(YouPanelClearanceWidth - 1f, LedgeYouPanel.FullHeight).y;
+
+            Assert.That(atClearance, Is.EqualTo(-Inset).Within(Tolerance),
+                "At exactly a PanelGap of clearance the toast keeps the top inset.");
+            Assert.That(justBelow, Is.EqualTo(-(Inset + LedgeYouPanel.FullHeight + Gap)).Within(Tolerance),
+                "One unit narrower the You panel is in the way and the toast drops below it.");
+        }
+
+        /// The two corners have different widths, so they bind at different
+        /// canvas widths. Between the thresholds only the You panel is in the way
+        /// and the toast must clear only that — dropping to the deeper HUD there
+        /// would waste vertical space no obstacle is using.
+        [Test]
+        public void BetweenThresholds_ClearsOnlyTheCornerItActuallyCollidesWith()
+        {
+            Assert.That(YouPanelClearanceWidth, Is.GreaterThan(ViewHudClearanceWidth),
+                "Premise: the wider You panel binds first, so a band exists where only it collides.");
+
+            float width = 0.5f * (YouPanelClearanceWidth + ViewHudClearanceWidth);
+            var pos = Resolve(width, LedgeYouPanel.FullHeight);
+            var toast = Toast(width, pos);
+
+            Assert.That(pos.y, Is.EqualTo(-(Inset + LedgeYouPanel.FullHeight + Gap)).Within(Tolerance),
+                "Only the You panel collides here, so its height is the clearance.");
+            Assert.That(toast.Overlaps(YouPanel()), Is.False);
+            Assert.That(toast.Overlaps(ViewHud(width)), Is.False);
+        }
+
+        // ── Degenerate inputs ───────────────────────────────────────────
+
+        [Test]
+        public void NoCornerChrome_KeepsTheTopCenterInset()
+        {
+            var pos = StatusBanner.ResolveToastAnchoredPosition(PortraitCanvasWidth, 0f, 0f, 0f, 0f);
+
+            Assert.That(pos.y, Is.EqualTo(-Inset).Within(Tolerance),
+                "With nothing in the top band the toast has no reason to move.");
+        }
+
+        /// The banner's Awake runs before the canvas has been laid out, so the
+        /// first layout pass can see a zero-width canvas. It must fall back to the
+        /// accepted placement rather than compute a nonsense drop.
+        [Test]
+        public void UnlaidOutCanvas_KeepsTheTopCenterInset()
+        {
+            Assert.That(Resolve(0f, LedgeYouPanel.FullHeight).y, Is.EqualTo(-Inset).Within(Tolerance));
+            Assert.That(Resolve(-1f, LedgeYouPanel.FullHeight).y, Is.EqualTo(-Inset).Within(Tolerance));
+        }
+
+        // ── Helpers ─────────────────────────────────────────────────────
+
+        private static Vector2 Resolve(float canvasWidth, float youPanelHeight)
+        {
+            return StatusBanner.ResolveToastAnchoredPosition(
+                canvasWidth,
+                LedgeYouPanel.PanelWidth, youPanelHeight,
+                BoardViewHud.HudWidth, BoardViewHud.HudHeight);
+        }
+
+        // Rects are expressed in "canvas top-down" space: x from the canvas left
+        // edge, y as depth below the canvas top edge. All three surfaces are
+        // top-anchored, so this keeps the overlap math readable — and Rect.Overlaps
+        // only needs both rects to share a convention, not a handedness.
+        private static Rect Toast(float canvasWidth, Vector2 anchoredPosition)
+        {
+            return new Rect(
+                canvasWidth * 0.5f + anchoredPosition.x - StatusBanner.ToastWidth * 0.5f,
+                -anchoredPosition.y,
+                StatusBanner.ToastWidth,
+                StatusBanner.ToastHeight);
+        }
+
+        private static Rect YouPanel(float height = LedgeYouPanel.FullHeight)
+        {
+            return new Rect(Inset, Inset, LedgeYouPanel.PanelWidth, height);
+        }
+
+        private static Rect ViewHud(float canvasWidth)
+        {
+            return new Rect(
+                canvasWidth - Inset - BoardViewHud.HudWidth, Inset,
+                BoardViewHud.HudWidth, BoardViewHud.HudHeight);
+        }
+    }
+}

--- a/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/StatusBannerLayoutContractTests.cs.meta
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/StatusBannerLayoutContractTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3b7f2c9d84a615e4a9c0d5f18e26b74c

--- a/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeYouPanel.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeYouPanel.cs
@@ -69,9 +69,13 @@ namespace Magi.LedgeBoardGame.UI
         // Full chrome vs the slim Comparison-view variant. Compact keeps the
         // identity strip + action line and drops the tone tracker / sub line,
         // so the panel stops crowding the SEATS strip at 3+ seats.
-        private const float PanelWidth = 360f;
-        private const float FullHeight = 130f;
-        private const float CompactHeight = 80f;
+        //
+        // Public because this panel owns the top-left corner of the top band and
+        // other top chrome has to place itself around it — see
+        // StatusBanner.ResolveToastAnchoredPosition (CP073).
+        public const float PanelWidth = 360f;
+        public const float FullHeight = 130f;
+        public const float CompactHeight = 80f;
 
         // Row geometry, in content-local space (the glass panel insets its
         // content by PanelPadX/PanelPadY, so y=0 is already inside the padding).


### PR DESCRIPTION
## Summary

- The transient phase toast (`StatusBanner`) sat at a fixed top-center inset. That clears the top-corner chrome at the 1920-unit reference width, but not on a phone: a 720x1280 screen scales to ~1080 canvas units, where the centered 560-wide toast spans 260..820 and lands on both the 360-wide top-left You panel (28..388) and the 280-wide top-right Board View HUD (772..1052) at the same top inset. The translucent toast box covered the "Place Light" headline and the TURN 1 eyebrow.
- `StatusBanner` now resolves its vertical slot from canvas geometry: when the centered toast cannot clear a top-corner panel by a `PanelGap`, it drops below the deeper of the panels it actually collides with. The transient surface yields rather than the persistent one, since the You panel is the "what do I do now" read.
- Wide/landscape layouts keep the accepted top-center inset placement. Centering, styling, fade timing and raycast/passive behaviour are unchanged.
- The breakpoint is derived from `PanelEdgeInset`/`PanelGap`, the toast width and the measured panel rects — not a resolution string — so retuning a token or resizing a panel moves the breakpoint with it.
- Corner panels are measured live rather than assumed, so the You panel's Comparison-view compact toggle and an absent/hidden panel are both handled without extra cases.
- Supporting API only: `BoardViewHud.Root` (the component builds its panel as a canvas sibling, so its own transform is not the panel rect) plus footprint constants on `BoardViewHud` and `LedgeYouPanel`, which also replace magic numbers at their own build sites.

## Tests / evidence

- New EditMode contract: `StatusBannerLayoutContractTests` — 11 deterministic geometry tests against `StatusBanner.ResolveToastAnchoredPosition`, the same pure function the runtime layout pass calls. Covers the locked-in defect premise, portrait clearance of both corners with a real `PanelGap` of air, the compact You panel case, landscape preservation of `-PanelEdgeInset`, the token-derived breakpoint (exact width and one unit narrower), the band where only one corner binds, and degenerate/unlaid-out canvas inputs.
- Focused live Unity EditMode run: **11/11 passed**, 0 failed, 0 skipped.
- Real Unity Play Mode runtime evidence via the Practice route — no mock UI, no in-game toggle, natural phase-toast timing:
  - Portrait 720x1280: `bannerAnchored=(0.0, -186.0)`, `toast_vs_you=false`, `toast_vs_hud=false`, measured gaps 18.7px / 9.3px.
  - Landscape 1920x1080: `bannerAnchored=(0.0, -28.0)` (original placement preserved), `toast_vs_you=false`, `toast_vs_hud=false`.
- Editor state at the pre-PR gate: not playing, not compiling, not updating, no failures, no dirty assets.
- `git diff --check`: clean.

## Reviews

- Codex: `approve_with_notes` — no blocking issues.
- Gemini/agy source review: `approve` — no blocking issues.
- Claude Design: `approve` — no visual blockers; recommended next step was to proceed to PR.

## Nonblocking follow-ups (carry-forward, unchanged by this PR)

Design flagged these as pre-existing and out of scope here:

- Portrait `BOARD VIEW` caps-label contrast and broken glyphs.
- The CP066 italic decision.
- 2-seat portrait dead-space composition.
- Pan/zoom overlap clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
