### PR TITLE
fix(ledge): restore board view label readability

### DIFF
--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardViewHud.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/BoardViewHud.cs
@@ -18,10 +18,42 @@ namespace Magi.LedgeBoardGame.Board
         public const float HudWidth = 280f;
         public const float HudHeight = 144f;
 
+        // ── Section-label readability (CP074) ────────────────────────────
+        // The kit's caps-caption recipe — SectionLabelSize 9.5, uppercase,
+        // 0.22em tracking, InkDim — is authored in canvas reference units
+        // against 1920x1080. The CanvasScaler (ScaleWithScreenSize, match 0.5)
+        // then scales the whole canvas by screen size, so those units are not a
+        // physical size: at 720x1280 the factor is ~0.67, and a 9.5-unit caption
+        // renders at ~6.3 physical px. LiberationSans SDF — which MonoFont
+        // actually resolves to, since the project ships no JetBrainsMono asset —
+        // has a cap line at 59/86 of em, so the capitals stand ~4.3px tall and
+        // their stems fall under half a pixel. That is what Design has been
+        // reading as broken glyphs on "BOARD VIEW": not a missing glyph (the
+        // fallback face carries every character in the string) but strokes too
+        // thin to survive SDF sampling, under an already-dim 40% ink.
+        //
+        // Fix holds the caption's *physical* size instead of its unit size, so
+        // the label renders the same on a phone as it does in the accepted
+        // landscape frame.
+        private const float SectionLabelRowHeight = 14f;
+        // Ceiling on the grow-up. TMP's TopLeft alignment pins the ascender line
+        // to the rect top and LiberationSans SDF ascends 0.905em, so the 14-unit
+        // row holds a hair over 15 units of type before the caps start clipping;
+        // an extremely narrow window would otherwise ask for more than that.
+        private const float SectionLabelMaxSize = 15f;
+        // Tracking earns its keep at display sizes and works against this one:
+        // 0.22em between 4px capitals reads as loose debris rather than a word.
+        // 0.14em is the value the You panel's turn-meta caption already uses, so
+        // this stays inside the family rather than inventing a number.
+        private const float SectionLabelTracking = 14f;
+
         private MultiBoardLayout _layout;
         private LedgeButton _toggleButton;
         private RectTransform _comparisonGroup;
         private TextMeshProUGUI _opponentLabel;
+        private TextMeshProUGUI _sectionLabel;
+        private Canvas _canvas;
+        private float _lastCanvasScaleFactor = -1f;
         private RectTransform _root;
 
         /// The top-right glass panel this component builds under the canvas. Note
@@ -77,6 +109,7 @@ namespace Magi.LedgeBoardGame.Board
         {
             var canvas = GetComponentInParent<Canvas>();
             if (canvas == null) return;
+            _canvas = canvas;
 
             var root = new GameObject("BoardViewHud", typeof(RectTransform));
             var rootRect = (RectTransform)root.transform;
@@ -99,7 +132,8 @@ namespace Magi.LedgeBoardGame.Board
 
             // Section label "BOARD VIEW" at the top — matches the mono
             // section-caption convention used by the other chrome panels
-            // so this reads as part of the same panel family.
+            // so this reads as part of the same panel family. Size and tracking
+            // are CP074's: see SectionLabelMaxSize / ApplySectionLabelScale.
             var labelHostGo = new GameObject("SectionLabel", typeof(RectTransform));
             var sectionRt = (RectTransform)labelHostGo.transform;
             sectionRt.SetParent(glass.Content, false);
@@ -107,16 +141,16 @@ namespace Magi.LedgeBoardGame.Board
             sectionRt.anchorMax = new Vector2(1f, 1f);
             sectionRt.pivot = new Vector2(0f, 1f);
             sectionRt.anchoredPosition = Vector2.zero;
-            sectionRt.sizeDelta = new Vector2(0f, 14f);
-            var sectionLabel = labelHostGo.AddComponent<TextMeshProUGUI>();
-            sectionLabel.text = "BOARD VIEW";
-            sectionLabel.font = LedgeUITokens.MonoFont;
-            sectionLabel.fontSize = LedgeUITokens.SectionLabelSize;
-            sectionLabel.color = LedgeUITokens.InkDim;
-            sectionLabel.fontStyle = FontStyles.UpperCase;
-            sectionLabel.characterSpacing = 22f;
-            sectionLabel.alignment = TextAlignmentOptions.TopLeft;
-            sectionLabel.raycastTarget = false;
+            sectionRt.sizeDelta = new Vector2(0f, SectionLabelRowHeight);
+            _sectionLabel = labelHostGo.AddComponent<TextMeshProUGUI>();
+            _sectionLabel.text = "BOARD VIEW";
+            _sectionLabel.font = LedgeUITokens.MonoFont;
+            _sectionLabel.color = LedgeUITokens.InkDim;
+            _sectionLabel.fontStyle = FontStyles.UpperCase;
+            _sectionLabel.characterSpacing = SectionLabelTracking;
+            _sectionLabel.alignment = TextAlignmentOptions.TopLeft;
+            _sectionLabel.raycastTarget = false;
+            ApplySectionLabelScale();
 
             // Toggle button — Ghost variant, pinned beneath the section label.
             var toggleHost = new GameObject("Toggle", typeof(RectTransform));
@@ -179,6 +213,41 @@ namespace Magi.LedgeBoardGame.Board
             var nextLe = next.gameObject.AddComponent<LayoutElement>();
             nextLe.preferredWidth = 44f;
             nextLe.minWidth = 44f;
+        }
+
+        /// Caps-caption size in canvas units that renders at the authored
+        /// physical size under a given <c>Canvas.scaleFactor</c>.
+        ///
+        /// The canvas scale factor is physical-pixels-per-canvas-unit, so
+        /// dividing by it converts "9.5 px on screen" into canvas units. Clamped
+        /// at both ends: never below the authored size, so the accepted
+        /// landscape frame (factor 1 at the 1920-wide reference, and every
+        /// factor above it) is pixel-identical to before CP074; and never above
+        /// what the caption row can hold, so a very narrow window degrades to a
+        /// smaller-than-ideal caption rather than a clipped one.
+        public static float ResolveSectionLabelSize(float canvasScaleFactor)
+        {
+            if (canvasScaleFactor <= 0f) return LedgeUITokens.SectionLabelSize;
+            return Mathf.Clamp(LedgeUITokens.SectionLabelSize / canvasScaleFactor,
+                               LedgeUITokens.SectionLabelSize, SectionLabelMaxSize);
+        }
+
+        // Re-fit when the canvas scale changes (window resize, device rotation).
+        // One float compare a frame; the caption is the only thing here sized in
+        // physical rather than reference units.
+        private void Update()
+        {
+            if (_sectionLabel == null || _canvas == null) return;
+            if (Mathf.Approximately(_canvas.scaleFactor, _lastCanvasScaleFactor)) return;
+            ApplySectionLabelScale();
+        }
+
+        private void ApplySectionLabelScale()
+        {
+            if (_sectionLabel == null) return;
+            float factor = _canvas != null ? _canvas.scaleFactor : 1f;
+            _lastCanvasScaleFactor = factor;
+            _sectionLabel.fontSize = ResolveSectionLabelSize(factor);
         }
 
         private void OnToggleClicked()

--- a/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/BoardViewHudSectionLabelContractTests.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/BoardViewHudSectionLabelContractTests.cs
@@ -1,0 +1,208 @@
+using System.Reflection;
+using NUnit.Framework;
+using TMPro;
+using UnityEngine;
+using Magi.LedgeBoardGame.Board;
+using Magi.LedgeBoardGame.UI;
+
+namespace Magi.LedgeBoardGame.Tests.EditMode
+{
+    /// CP074: the top-right "BOARD VIEW" caps caption must render at a readable
+    /// physical size in portrait, not just in the landscape reference frame.
+    ///
+    /// The kit's caption recipe (SectionLabelSize 9.5, uppercase, tracked-out,
+    /// InkDim) is authored in canvas reference units against 1920x1080. The
+    /// CanvasScaler then scales the canvas by screen size, so those units are
+    /// not a physical size: at 720x1280 the factor is ~0.67 and the caption
+    /// renders at ~6.3px, whose capitals stand ~4.3px tall with sub-half-pixel
+    /// stems. Design read that as broken glyphs across CP071-CP073.
+    ///
+    /// These tests assert the contract in the units Design actually judges —
+    /// physical pixels and cap height — against the pure resolver the runtime
+    /// layout calls, and against the font asset the game really resolves
+    /// (MonoFont falls back to LiberationSans SDF; no JetBrainsMono asset ships).
+    [TestFixture]
+    public class BoardViewHudSectionLabelContractTests
+    {
+        // Main.unity's canvas: ScaleWithScreenSize, MatchWidthOrHeight, 0.5.
+        private const float ReferenceWidth = 1920f;
+        private const float ReferenceHeight = 1080f;
+        private const float Match = 0.5f;
+
+        // The portrait frame Design has been capturing.
+        private const float PortraitScreenWidth = 720f;
+        private const float PortraitScreenHeight = 1280f;
+
+        private const float Authored = LedgeUITokens.SectionLabelSize;
+        private const float Tolerance = 0.01f;
+
+        // ── The accepted landscape frame is untouched ────────────────────
+
+        [Test]
+        public void LandscapeReferenceFrame_KeepsTheAuthoredCaptionSize()
+        {
+            float factor = CanvasScaleFactor(ReferenceWidth, ReferenceHeight);
+
+            Assert.That(factor, Is.EqualTo(1f).Within(Tolerance), "Premise: the reference frame scales 1:1.");
+            Assert.That(BoardViewHud.ResolveSectionLabelSize(factor), Is.EqualTo(Authored).Within(Tolerance),
+                "CP074 must not touch the frame Design already accepted.");
+        }
+
+        /// A 4K window scales the canvas up, which makes the authored size
+        /// physically larger, not smaller. Growing it further would be a
+        /// redesign of the caption, not a readability floor.
+        [Test]
+        public void HighDpiFrame_NeverShrinksBelowTheAuthoredSize()
+        {
+            Assert.That(BoardViewHud.ResolveSectionLabelSize(2f), Is.EqualTo(Authored).Within(Tolerance));
+            Assert.That(BoardViewHud.ResolveSectionLabelSize(1.5f), Is.EqualTo(Authored).Within(Tolerance));
+        }
+
+        // ── Portrait ─────────────────────────────────────────────────────
+
+        [Test]
+        public void PortraitPhone_RendersTheCaptionAtTheAuthoredPhysicalSize()
+        {
+            float factor = PortraitScaleFactor;
+            float resolved = BoardViewHud.ResolveSectionLabelSize(factor);
+
+            Assert.That(resolved, Is.GreaterThan(Authored),
+                "Portrait has to grow the caption in canvas units to hold its physical size.");
+            Assert.That(resolved * factor, Is.EqualTo(Authored).Within(Tolerance),
+                "On screen the caption must measure what it measures in landscape.");
+        }
+
+        /// The readability contract in the terms Design judges: how many physical
+        /// pixels tall the capitals actually stand.
+        [Test]
+        public void PortraitPhone_CapHeightMatchesTheLandscapeBaseline()
+        {
+            float landscape = CapHeightPx(Authored, 1f);
+            float portrait = CapHeightPx(BoardViewHud.ResolveSectionLabelSize(PortraitScaleFactor), PortraitScaleFactor);
+
+            Assert.That(portrait, Is.GreaterThanOrEqualTo(landscape - Tolerance),
+                $"Portrait caps stand {portrait:0.00}px against the accepted landscape {landscape:0.00}px.");
+        }
+
+        /// Guards the premise. If this ever fails, portrait no longer shrinks the
+        /// caption and the rest of this fixture is defending a solved problem.
+        [Test]
+        public void OriginalFixedSize_WouldHaveRenderedFarBelowTheLandscapeBaseline()
+        {
+            float landscape = CapHeightPx(Authored, 1f);
+            float before = CapHeightPx(Authored, PortraitScaleFactor);
+
+            Assert.That(before, Is.LessThan(landscape - 1f),
+                "The CP074 defect: a fixed unit size loses more than a pixel of cap height in portrait.");
+        }
+
+        // ── Fit budget ───────────────────────────────────────────────────
+
+        /// A window narrow enough would ask for a caption taller than its row.
+        /// It degrades to the largest size that fits rather than clipping.
+        [Test]
+        public void ExtremelyNarrowCanvas_ClampsToTheCaptionRowBudget()
+        {
+            float max = PrivateConst("SectionLabelMaxSize");
+
+            Assert.That(BoardViewHud.ResolveSectionLabelSize(0.4f), Is.EqualTo(max).Within(Tolerance));
+            Assert.That(BoardViewHud.ResolveSectionLabelSize(0.1f), Is.EqualTo(max).Within(Tolerance));
+            Assert.That(max, Is.GreaterThan(Authored), "The ceiling has to leave room above the authored size.");
+        }
+
+        /// TMP's TopLeft alignment pins the ascender line to the rect top, so the
+        /// row holds rowHeight / ascentRatio units of type. Asserted against the
+        /// live font asset rather than a copied metric, so swapping the caption
+        /// face retunes the budget instead of silently clipping it.
+        [Test]
+        public void CaptionRow_CanHoldTheLargestResolvedSize()
+        {
+            var font = LedgeUITokens.MonoFont;
+            Assert.That(font, Is.Not.Null, "No caption font resolved — not even the TMP fallback.");
+
+            float rowHeight = PrivateConst("SectionLabelRowHeight");
+            float max = PrivateConst("SectionLabelMaxSize");
+            float ascentRatio = font.faceInfo.ascentLine / font.faceInfo.pointSize;
+
+            Assert.That(max * ascentRatio, Is.LessThanOrEqualTo(rowHeight),
+                $"A {max} unit caption ascends {max * ascentRatio:0.00} units into a {rowHeight} unit row.");
+        }
+
+        [Test]
+        public void PortraitPhone_ResolvedSizeStillFitsTheCaptionRow()
+        {
+            var font = LedgeUITokens.MonoFont;
+            float rowHeight = PrivateConst("SectionLabelRowHeight");
+            float ascentRatio = font.faceInfo.ascentLine / font.faceInfo.pointSize;
+            float resolved = BoardViewHud.ResolveSectionLabelSize(PortraitScaleFactor);
+
+            Assert.That(resolved * ascentRatio, Is.LessThanOrEqualTo(rowHeight),
+                "The portrait caption must fit its row without the ceiling having to catch it.");
+        }
+
+        // ── Tracking ─────────────────────────────────────────────────────
+
+        /// The second half of the defect: 0.22em of tracking scatters 4px
+        /// capitals into unrelated marks. Tightened to the value the You panel's
+        /// turn-meta caption already uses, so this stays inside the family.
+        [Test]
+        public void Tracking_IsTightenedButStillReadsAsACaption()
+        {
+            float tracking = PrivateConst("SectionLabelTracking");
+
+            Assert.That(tracking, Is.LessThan(22f), "CP074 tightens the caption tracking.");
+            Assert.That(tracking, Is.GreaterThan(0f), "Caps captions in this kit are tracked out, not set solid.");
+        }
+
+        // ── The glyphs were never missing ────────────────────────────────
+
+        /// Design described "broken glyphs", which invites a missing-glyph fix
+        /// (importing a font, changing the string). This pins the real cause: the
+        /// resolved face carries every character in the caption, so the defect is
+        /// rasterisation at size, and CP074 is right to treat it as such.
+        [Test]
+        public void ResolvedCaptionFont_CarriesEveryCharacterInTheCaption()
+        {
+            var font = LedgeUITokens.MonoFont;
+            Assert.That(font, Is.Not.Null);
+
+            const string caption = "BOARD VIEW";
+            foreach (char c in caption)
+            {
+                if (char.IsWhiteSpace(c)) continue;
+                Assert.That(font.HasCharacter(c), Is.True,
+                    $"'{c}' is missing from {font.name} — this would be a genuine missing-glyph defect.");
+            }
+        }
+
+        // ── Helpers ─────────────────────────────────────────────────────
+
+        private static float PortraitScaleFactor =>
+            CanvasScaleFactor(PortraitScreenWidth, PortraitScreenHeight);
+
+        /// CanvasScaler.ScaleWithScreenSize / MatchWidthOrHeight, reproduced so
+        /// the tests read in screen resolutions rather than a magic factor.
+        private static float CanvasScaleFactor(float screenWidth, float screenHeight)
+        {
+            float logWidth = Mathf.Log(screenWidth / ReferenceWidth, 2f);
+            float logHeight = Mathf.Log(screenHeight / ReferenceHeight, 2f);
+            return Mathf.Pow(2f, Mathf.Lerp(logWidth, logHeight, Match));
+        }
+
+        /// Physical pixels of capital height for a caption of <paramref name="sizeInCanvasUnits"/>.
+        private static float CapHeightPx(float sizeInCanvasUnits, float canvasScaleFactor)
+        {
+            var font = LedgeUITokens.MonoFont;
+            Assert.That(font, Is.Not.Null);
+            float capRatio = font.faceInfo.capLine / font.faceInfo.pointSize;
+            return sizeInCanvasUnits * canvasScaleFactor * capRatio;
+        }
+
+        private static float PrivateConst(string name)
+        {
+            var field = typeof(BoardViewHud).GetField(name, BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(field, Is.Not.Null, $"BoardViewHud.{name} not found — was it renamed?");
+            return (float)field.GetValue(null);
+        }
+    }
+}

--- a/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/BoardViewHudSectionLabelContractTests.cs.meta
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/BoardViewHudSectionLabelContractTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6e4a12c7b53d09f4bb7e83c1d05fa629

--- a/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/Ledge.Tests.EditMode.asmdef
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/Ledge.Tests.EditMode.asmdef
@@ -3,6 +3,7 @@
     "rootNamespace": "Magi.LedgeBoardGame.Tests.EditMode",
     "references": [
         "Magi.LedgeBoardGame",
+        "Unity.TextMeshPro",
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner"
     ],


### PR DESCRIPTION
## Summary

- The top-right `BOARD VIEW` caps caption has read as broken glyphs in portrait since CP071 — the worst remaining caps-label instance on Design's ledger.
- Root cause is rasterisation at size, not a missing glyph. The kit's caption recipe (`SectionLabelSize` 9.5, uppercase, 0.22em tracking, `InkDim`) is authored in canvas reference units against 1920x1080; the CanvasScaler (`ScaleWithScreenSize`, `MatchWidthOrHeight` 0.5) then scales the whole canvas by screen size, so those units are not a physical size. At 720x1280 the factor is ~0.667, so the 9.5-unit caption rendered at ~6.3 physical px — capitals ~4.3px tall with sub-half-pixel stems, under an already-dim 40% ink.
- The resolved face was never the problem: `MonoFont` already falls back to LiberationSans SDF (no JetBrainsMono asset ships), and that face carries every character in the string. The new contract asserts this directly so the defect can't be re-diagnosed as a font import.
- `BoardViewHud` now sizes the caption from `Canvas.scaleFactor`, holding its authored **physical** size rather than its unit size. Portrait renders at 9.5px with a 6.5px cap height — identical to the landscape frame Design accepted.
- The resolver clamps at both ends: never below the authored size, so factor 1 and every factor above it (windowed 16:9, 4K, high-DPI) is pixel-identical to before this PR; and never above what the 14-unit caption row can hold, so a very narrow window degrades to a smaller-than-ideal caption rather than a clipped one.
- Tracking drops 0.22em → 0.14em, the value the You panel's turn-meta caption already uses — that much tracking between 4px capitals reads as loose debris rather than a word. This is the only visible landscape change.
- Ink stays at `InkDim` 0.40 per Design: contrast is restored by recovering stroke coverage, not by raising alpha.
- Scope held to this one caption. `HudWidth`/`HudHeight` are unchanged, so CP073's toast geometry is untouched.

## Test plan

- **Focused live Unity EditMode: 10/10 passed**, 0 failed, 0 skipped (`BoardViewHudSectionLabelContractTests`). The contract asserts in the units Design judges — physical pixels and cap height — against the pure resolver the runtime path calls, and against the live font asset, so swapping the caption face retunes the fit budget instead of silently clipping it. It also locks the defect premise: a fixed unit size must lose more than a pixel of cap height in portrait.
- **Real Unity Play Mode runtime evidence** (no mock UI, no A/B toggle):
  - Portrait 720x1280: `sectionText=BOARD VIEW`, `canvasScale=0.667`, `fontSize=14.250`, `physicalSizePx=9.500`, `capHeightPx=6.517`, `tracking=14`, `section_vs_toggle=false`, `section_inside_hud=true`.
  - Landscape 1920x1080: `canvasScale=1.000`, `fontSize=9.500`, `physicalSizePx=9.500`, `capHeightPx=6.517`, `tracking=14`, `section_vs_toggle=false`, `section_inside_hud=true`.
  - Identical `physicalSizePx` and `capHeightPx` across both orientations is the property this PR set out to establish; landscape landing exactly on the authored 9.5 confirms the lower clamp holds the accepted frame.
- **CP073 no-regression**, same frames: `toast_vs_you=false` and `toast_vs_hud=false` in both orientations.
- `git diff --check`: clean. (Git still emits its CRLF-conversion advisory for the asmdef; that is not a check failure.)
- **Reviews** — Codex `approve_with_notes`, Gemini/agy `approve`, Claude Design `approve_with_notes`. No blocking issues and no visual blockers from any of the three; Design recorded the `BOARD VIEW` broken-glyph item as closed structurally.
- **DesignSync**: project `Ledge Board Game`, prefix `handoff/cp074-boardview-label-readability-2026-09-02/`, independently verified 19/19 present — no missing, extras, deletes or overwrites.

## Supporting changes

- `Ledge.Tests.EditMode.asmdef` gains a `Unity.TextMeshPro` reference. This is required, not incidental: without it the new tests fail to compile with `CS0012` because the contract reads real `TMP_FontAsset` metrics. `overrideReferences: true` governs `precompiledReferences` only, so an asmdef reference is sufficient.
- The same asmdef is normalised to LF. It previously had mixed line endings (most lines CRLF, a block of LF), and with `core.autocrlf=true` and no `.gitattributes` any CRLF-terminated added line trips `git diff --check`. LF is what Unity's own asmdef writer emits and what the existing block already used. No semantic JSON change beyond the added reference.

## Carry-forward from Claude Design (nonblocking, not addressed here)

- Leave `InkDim` at 0.40. Conditional only: if playtests report players missing Compare, the first lever is alpha ~0.55 on this one label.
- Remaining caps-label ink ledger, in Design's order: `SEATS N` first, then the `LIGHT/DARK` tone tracker, then `HOW IT TURNED`.
- Unchanged open items: the CP066 italic decision, 2-seat portrait dead-space composition, pan/zoom overlap clamp, and the stray white circle recurring since CP069.
- The physical-size resolver is deliberately local to `BoardViewHud`. The same reasoning applies to every `SectionLabelSize` caption in portrait, so promoting it to a shared `LedgeUITokens` helper is the natural follow-up if Design wants the whole caption family fixed.
- `SectionLabelMaxSize = 15` is derived from the 14-unit row and the 0.905em ascent of the currently-resolved fallback face. The test recomputes that budget from the live asset, so importing a real JetBrainsMono later fails the assertion rather than clipping — but the literal would then want revisiting.
- No in-place live resize/rotation capture was taken. Both source reviewers judged the per-frame path simple enough not to block: a single float compare against the cached `scaleFactor` with an early-out, matching the idiom already shipping in `LedgeSettingsPanel`, `LedgeSetupPanel` and CP073's `StatusBanner`.

## CI

This repository may report no CI checks on the branch. If `gh pr checks` returns empty, that means **no checks were reported** — it does not mean CI passed. Verified state is recorded in the result block accompanying this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
