### PR TITLE
fix(ledge): make You panel headline upright

### DIFF
--- a/LedgeBoardGame/Assets/_Project/Scripts/Board/StatusBanner.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Board/StatusBanner.cs
@@ -98,8 +98,18 @@ namespace Magi.LedgeBoardGame.Board
                 label = labelGo.AddComponent<TextMeshProUGUI>();
                 label.alignment = TextAlignmentOptions.Center;
                 label.fontSize = LedgeUITokens.TurnBannerSize;
-                // Display font (Fraunces italic) for the theatrical "Your turn" feel
-                // when the asset is present; falls back to UI font otherwise.
+                // DisplayFont italic — the theatrical, ceremonial voice, kept
+                // here on purpose (CP076). This toast NARRATES: transient,
+                // third-person copy about events and players ("Player2 wins!",
+                // "Player1 eliminated.", "… no legal moves — turn skipped").
+                // The You-panel action headline draws the same DisplayFont at
+                // the same TurnBannerSize but UPRIGHT, because it INSTRUCTS —
+                // persistent second-person imperatives ("Place Light", "Select
+                // a stack"). The style bit is the only thing carrying that
+                // distinction, so do not "align" the two for consistency; the
+                // asymmetry is the design. LedgeTypeVoiceTests pins both sides.
+                // (DisplayFont falls back to the UI font when no display asset
+                // is imported, in which case TMP synthesises the oblique.)
                 label.font = LedgeUITokens.DisplayFont;
                 label.fontStyle = FontStyles.Italic;
                 label.color = LedgeUITokens.Ink;

--- a/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/LedgeTypeVoiceTests.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/LedgeTypeVoiceTests.cs
@@ -1,0 +1,169 @@
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using TMPro;
+using UnityEngine;
+using Magi.LedgeBoardGame.Board;
+using Magi.LedgeBoardGame.UI;
+
+namespace Magi.LedgeBoardGame.Tests.EditMode
+{
+    /// Pins the CP076 type-voice rule, in both directions:
+    ///
+    ///   italic  = the game NARRATING — transient, third-person event and
+    ///             ceremony copy ("Player2 wins!", "Player1 eliminated.",
+    ///             "… no legal moves — turn skipped"). StatusBanner.
+    ///   upright = the interface INSTRUCTING — persistent, second-person
+    ///             imperatives the player must act on ("Place Light",
+    ///             "Select a stack", "Choose destination"). LedgeYouPanel.
+    ///
+    /// Both surfaces draw the same DisplayFont at the same TurnBannerSize (32f),
+    /// so the ONLY thing separating them is the style bit — which makes this
+    /// exactly the kind of deliberate asymmetry a later reader "fixes" by
+    /// accident in the name of consistency. Hence a test on each side rather
+    /// than a comment on each side.
+    ///
+    /// Note the asymmetry in what these two tests are FOR: the You-panel test
+    /// was written red-first against the CP076 change and is the regression
+    /// guard. The StatusBanner test never failed — it is a lock on the half of
+    /// the ruling that deliberately did NOT change, so that flipping it becomes
+    /// a conscious act with a red test attached.
+    [TestFixture]
+    public class LedgeTypeVoiceTests
+    {
+        private readonly List<GameObject> _spawned = new List<GameObject>();
+
+        [TearDown]
+        public void TearDown()
+        {
+            for (int i = 0; i < _spawned.Count; i++)
+                if (_spawned[i] != null) Object.DestroyImmediate(_spawned[i]);
+            _spawned.Clear();
+        }
+
+        private GameObject Spawn(string name)
+        {
+            var go = new GameObject(name, typeof(RectTransform));
+            _spawned.Add(go);
+            return go;
+        }
+
+        private static TMP_Text FindLabel(GameObject root, string childName)
+        {
+            foreach (var t in root.GetComponentsInChildren<TMP_Text>(true))
+                if (t.gameObject.name == childName) return t;
+            return null;
+        }
+
+        /// The You panel exposes EnsureBuilt(), so it needs no special handling.
+        private LedgeYouPanel BuildYouPanel()
+        {
+            var panel = Spawn("YouPanelUnderTest").AddComponent<LedgeYouPanel>();
+            panel.EnsureBuilt();
+            return panel;
+        }
+
+        /// StatusBanner builds its label in a private EnsureVisuals() called
+        /// from Awake, and Unity does not run Awake for a component added by
+        /// script outside Play Mode (only [ExecuteAlways] types get that). So
+        /// the label genuinely does not exist unless the lifecycle is driven
+        /// here — the earlier "Label not found" failures were this test's
+        /// setup, not a change in the production surface.
+        ///
+        /// Driving Awake by reflection rather than adding a public build
+        /// entrypoint: CP076's scope is one style property, and StatusBanner is
+        /// explicitly comment-only in this pass. Widening its public API purely
+        /// for a test would be the larger change of the two. Reflection into
+        /// private members already has precedent here — see
+        /// BoardViewHudSectionLabelContractTests.PrivateConst.
+        private StatusBanner BuildStatusBanner()
+        {
+            var go = Spawn("StatusBannerUnderTest");
+            // [RequireComponent] adds CanvasGroup on AddComponent; Awake reads
+            // it, so add it up front rather than relying on ordering.
+            go.AddComponent<CanvasGroup>();
+            var banner = go.AddComponent<StatusBanner>();
+
+            var awake = typeof(StatusBanner).GetMethod(
+                "Awake", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(awake, Is.Not.Null,
+                "StatusBanner.Awake not found — its lifecycle entrypoint was renamed, and this " +
+                "test can no longer drive the visual build.");
+            awake.Invoke(banner, null);
+            return banner;
+        }
+
+        [Test]
+        public void YouPanelActionHeadline_IsUpright_NotItalic()
+        {
+            var panel = BuildYouPanel();
+
+            var action = FindLabel(panel.gameObject, "ActionLabel");
+            Assert.IsNotNull(action, "ActionLabel not found — the You panel row layout changed.");
+
+            Assert.AreEqual(
+                (FontStyles)0,
+                action.fontStyle & FontStyles.Italic,
+                "The You-panel action headline carries second-person imperatives (\"Place Light\", " +
+                "\"Select a stack\"). It is interface instruction, not narration, so it must be " +
+                "upright. See CP076.");
+        }
+
+        /// Compact mode (Comparison view, 3+ seats) retunes the same label's
+        /// position and fontSizeMax. Upright has to survive that flip — a style
+        /// re-applied on one path and not the other is how this regresses.
+        [Test]
+        public void YouPanelActionHeadline_StaysUpright_AcrossCompactModeFlips()
+        {
+            var panel = BuildYouPanel();
+            var action = FindLabel(panel.gameObject, "ActionLabel");
+
+            panel.SetCompactMode(true);
+            Assert.AreEqual((FontStyles)0, action.fontStyle & FontStyles.Italic,
+                "Compact mode re-applied italic to the action headline.");
+
+            panel.SetCompactMode(false);
+            Assert.AreEqual((FontStyles)0, action.fontStyle & FontStyles.Italic,
+                "Returning to full mode re-applied italic to the action headline.");
+        }
+
+        [Test]
+        public void StatusBannerToast_StaysItalic_NarrationVoice()
+        {
+            var banner = BuildStatusBanner();
+
+            var label = FindLabel(banner.gameObject, "Label");
+            Assert.IsNotNull(label, "StatusBanner Label not found — its visual build changed.");
+
+            Assert.AreNotEqual(
+                (FontStyles)0,
+                label.fontStyle & FontStyles.Italic,
+                "The StatusBanner toast narrates events and ceremony in the third person " +
+                "(\"Player2 wins!\", \"Player1 eliminated.\"). Italic there is deliberate and is " +
+                "what keeps the upright You-panel headline meaningful as a separate voice. " +
+                "If this is being changed on purpose, revisit the CP076 ruling rather than " +
+                "just deleting the assert.");
+        }
+
+        [Test]
+        public void BothSurfaces_ShareSizeAndFont_SoStyleIsTheOnlyDistinction()
+        {
+            // If these ever stop matching, the CP076 rule loses its force: the two
+            // voices would then differ by size or family as well, and the style bit
+            // would no longer be carrying the distinction on its own.
+            var panel = BuildYouPanel();
+            var action = FindLabel(panel.gameObject, "ActionLabel");
+
+            var banner = BuildStatusBanner();
+            var label = FindLabel(banner.gameObject, "Label");
+            Assert.IsNotNull(label, "StatusBanner Label not found — its visual build changed.");
+
+            Assert.AreEqual(LedgeUITokens.TurnBannerSize, label.fontSize,
+                "StatusBanner no longer renders at TurnBannerSize.");
+            Assert.AreEqual(LedgeUITokens.TurnBannerSize, action.fontSizeMax,
+                "You-panel headline no longer tops out at TurnBannerSize.");
+            Assert.AreSame(action.font, label.font,
+                "The two voices no longer share a font asset.");
+        }
+    }
+}

--- a/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/LedgeTypeVoiceTests.cs.meta
+++ b/LedgeBoardGame/Assets/_Project/Scripts/Tests/EditMode/LedgeTypeVoiceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3e16e0eff63ef534aba66edc54022b73

--- a/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeUITokens.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeUITokens.cs
@@ -53,7 +53,7 @@ namespace Magi.LedgeBoardGame.UI
         public const float SectionLabelSize = 9.5f;    // mono, 0.22em tracking, uppercase
         public const float BodySize         = 12.5f;
         public const float IdentNameSize    = 15f;
-        public const float TurnBannerSize   = 32f;     // Fraunces italic
+        public const float TurnBannerSize   = 32f;     // display action/banner size; style is per-surface (CP076)
         public const float ButtonMdSize     = 12f;
         public const float ButtonSmSize     = 11f;
         public const float ButtonLgSize     = 13f;

--- a/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeYouPanel.cs
+++ b/LedgeBoardGame/Assets/_Project/Scripts/UI/LedgeYouPanel.cs
@@ -21,7 +21,17 @@ namespace Magi.LedgeBoardGame.UI
     ///      aligned. One quiet row instead of three loud ones. Identity and
     ///      wedge colour are still first-class, just no longer dominant.
     ///   2. Action line — the state-specific instruction, at display weight
-    ///      (TurnBannerSize, Fraunces italic). This is the panel now.
+    ///      (TurnBannerSize, DisplayFont upright). This is the panel now.
+    ///      Upright is deliberate (CP076) and is NOT an oversight to be
+    ///      "fixed" for consistency with the StatusBanner toast: italic is
+    ///      the game narrating (transient, third-person events and ceremony),
+    ///      upright is the interface instructing (persistent, second-person
+    ///      imperatives you must act on). This row is all imperatives —
+    ///      "Place Light", "Select a stack", "Choose destination" — so it
+    ///      takes the instruction voice. The italic it used to carry was
+    ///      inherited, not chosen: pre-CP066 this row held the aside
+    ///      "Player1's turn." at 22f, and the style rode along when CP066
+    ///      promoted it to a 32f command.
     ///   3. Tone tracker — placement only: which of Light/Dark is still owed.
     ///   4. Sub line — short supporting detail, the row that is dropped first.
     ///
@@ -201,7 +211,11 @@ namespace Magi.LedgeBoardGame.UI
             // ── Row 2: the action line — the panel's dominant read ──────
             _actionLabel = MakeText(content, "ActionLabel", LedgeUITokens.DisplayFont,
                 ActionSizeMax_Full, LedgeUITokens.Ink, "");
-            _actionLabel.fontStyle = FontStyles.Italic;
+            // Set Normal explicitly rather than omitting the line: an explicit
+            // upright is self-documenting and immune to whatever style the
+            // resolved font asset defaults to. See the class doc for why this
+            // row is upright while the StatusBanner toast stays italic (CP076).
+            _actionLabel.fontStyle = FontStyles.Normal;
             // Autosizing rather than a fixed size: "Waiting for <long name>" and
             // "Choose destination" have very different widths, and a 360px panel
             // has to hold both without clipping. Shrink first, ellipsize only if


### PR DESCRIPTION
## Summary
- Make the in-game You-panel action headline render upright (`FontStyles.Normal`) so persistent imperative prompts read as interface instruction.
- Keep `StatusBanner` toast text italic as the separate transient narration/ceremony voice, with comments documenting the CP076 ruling.
- Add EditMode type-voice guard tests covering You-panel upright style, compact-mode flips, StatusBanner italic retention, and shared font/size invariants.

## Verification
- Focused live Unity EditMode: `Passed`, `4/4`, XML: `LedgeBoardGame/Logs/cp076-typevoice-results-live.xml`
- Full live Unity EditMode: `Passed`, `145/145`, XML: `LedgeBoardGame/Logs/cp076-full-editmode-results-live.xml`
- Real Unity Play Mode screenshots captured for `Place Light`, `Place Dark`, `Select a stack`, `Choose destination`, mixed upright-panel/italic-toast, and 6-seat Comparison compact.
- Claude Design verdict: `approve`, no visual blockers.
- Codex final implementation review: `approve_with_notes`, no blockers.
- Gemini final implementation review: `approve`, no blockers.
- DesignSync handoff verified: `handoff/cp076-youpanel-headline-upright-2026-09-03/`, `30/30`, no missing/extras, deletes `[]`, no overwrites.

## Notes
- The CP076 visual change is intentionally subtle. It appears in the top-left in-game You panel action headline; the center toast remains italic by design.
- Existing unrelated ledger items called out by Design remain out of scope: landscape SEATS strip placement, recurring white circle identification, LIGHT/DARK tracker/HOW IT TURNED ink, 2-seat portrait dead space, and pan/zoom overlap clamp.
- Unrelated untracked local dirs `kit-import/` and `kit-import-v6/` were not staged.
